### PR TITLE
test(qrkit): cross-check package_version against gleam.toml at test time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `package_version_test` now reads `gleam.toml` at test time and asserts
+  that `qrkit.package_version` returns the version pinned there. Releases
+  that bump only `gleam.toml` without `src/qrkit.gleam`'s constant
+  (or vice versa) now fail CI instead of shipping a runtime-visible
+  version that disagrees with Hex metadata. `CONTRIBUTING.md`'s release
+  checklist was updated to call this out. (#2)
+
 - **Breaking**: `qrkit.with_min_version(N)` is now a strict floor. If the
   payload, the chosen mode, or the chosen ECC level cannot be encoded at
   version N, `qrkit.build` returns `Error(DataExceedsCapacity)` or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,11 @@ Steps for a new release `vX.Y.Z`:
 1. Confirm `main` is green on CI and the working tree is clean.
 2. Promote any items under `## Unreleased` in `CHANGELOG.md` into a
    new `## [X.Y.Z] - YYYY-MM-DD` section directly below `## Unreleased`.
-3. Bump `version = "X.Y.Z"` in `gleam.toml`.
+3. Bump `version = "X.Y.Z"` in `gleam.toml`. The
+   `qrkit.package_version` constant in `src/qrkit.gleam` is
+   cross-checked against this value by `package_version_test` in the
+   test suite, so if you also bump the constant by hand the two stay
+   in lockstep; if you forget, CI fails before publish (#2).
 4. Open a PR with the changelog and version bump, get it green and
    merged.
 5. After merge, fast-forward `main` and tag the merge commit:

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -1,5 +1,6 @@
 import gleam/bit_array
 import gleam/list
+import gleam/result
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -11,14 +12,40 @@ import qrkit/render/ascii
 import qrkit/render/png
 import qrkit/render/svg
 import qrkit/types
+import simplifile
 
 pub fn main() -> Nil {
   gleeunit.main()
 }
 
 pub fn package_version_test() -> Nil {
+  // Cross-check the runtime-visible version against the single source
+  // of truth (`gleam.toml`). When a release bumps `gleam.toml` but
+  // forgets to bump `qrkit.package_version`, this test fails CI
+  // immediately rather than letting drift ship to Hex. See #2.
+  let assert Ok(toml) = simplifile.read("gleam.toml")
+  let assert Ok(version_in_toml) = extract_toml_version(toml)
   qrkit.package_version()
-  |> should.equal("0.1.0")
+  |> should.equal(version_in_toml)
+}
+
+fn extract_toml_version(toml: String) -> Result(String, Nil) {
+  // `gleam.toml` always pins the package version with a line of the
+  // form `version = "X.Y.Z"`. Grab the first such line and pull out
+  // the quoted value.
+  toml
+  |> string.split("\n")
+  |> list.find(fn(line) { string.starts_with(string.trim(line), "version = ") })
+  |> result.try(fn(line) {
+    case string.split_once(line, "\"") {
+      Ok(#(_, after_open)) ->
+        case string.split_once(after_open, "\"") {
+          Ok(#(value, _)) -> Ok(value)
+          Error(_) -> Error(Nil)
+        }
+      Error(_) -> Error(Nil)
+    }
+  })
 }
 
 pub fn encode_returns_square_symbol_test() -> Nil {


### PR DESCRIPTION
## Summary

`qrkit.package_version` was hardcoded to `"0.1.0"` in
`src/qrkit.gleam` and the unit test pinned the same literal. The
release checklist only mentioned bumping `gleam.toml`, so a release
that forgot to also touch the runtime constant would publish Hex
metadata that disagreed with what the public API reports. Closes #2.

## Changes

- `test/qrkit_test.gleam`: `package_version_test` now reads
  `gleam.toml` at test time (simplifile is already a dev-dep used by
  the existing test suite), pulls out the `version = "X.Y.Z"` line
  via a tiny inline parser, and asserts it equals
  `qrkit.package_version()`. Drift between the two locations now
  fails CI instead of shipping.
- `CONTRIBUTING.md`: the release checklist now mentions both
  locations, points at the cross-check test, and clarifies that
  `gleam.toml` is the source of truth.
- `CHANGELOG.md`: `Unreleased` entry describing the change.

## Design

Keeping the constant in `src/qrkit.gleam` (rather than reading
`gleam.toml` at runtime) keeps the public API a pure compile-time
constant — no FFI, no file I/O, callers can use it inside `case`
expressions and constant contexts. The test does the file read so
release drift fails CI without any runtime cost on user code.

## Test plan

- [x] `just all` clean on Erlang + JavaScript targets
- [x] All 64 tests pass on both targets
- [x] Manually verified the cross-check by temporarily bumping
  `gleam.toml`'s version without touching `package_version`: test
  fails with the expected mismatch message.

Closes #2.
