### PR TITLE
fix: tighten qrkit public API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,23 @@ All notable changes to this project will be documented in this file.
   version that disagrees with Hex metadata. `CONTRIBUTING.md`'s release
   checklist was updated to call this out. (#2)
 
-- **Breaking**: `qrkit.with_min_version(N)` is now a strict floor. If the
-  payload, the chosen mode, or the chosen ECC level cannot be encoded at
-  version N, `qrkit.build` returns `Error(DataExceedsCapacity)` or
-  `Error(IncompatibleOptions)` instead of silently promoting to a larger
-  version. The historical "smallest fit" default is preserved for callers
-  that omit `with_min_version` entirely. This affects all three symbol
-  families (Standard QR, Micro QR, rMQR) and `qrkit.encode_split` is
-  unaffected (it still picks the smallest version per shard inside the
-  caller's `max_version` cap).
+- `qrkit/content` now escapes vCard / iCalendar text fields consistently
+  and uses proper URI percent-encoding for `mailto:` query parameters, so
+  reserved characters in user data no longer produce malformed payloads.
+  (#1)
+
+- `qrkit.with_exact_version/2` is now the preferred public API for exact
+  version pinning. `qrkit.with_min_version/2` remains available as a
+  compatibility alias, but its documentation now explicitly states that it
+  pins the version exactly rather than setting a lower bound. (#4)
+
+- **Breaking**: `qrkit.module_at/3` now returns
+  `Result(Bool, qrkit.MatrixAccessError)` instead of silently treating
+  out-of-bounds coordinates as light modules. Builder ECI validation is now
+  explicit as well: invalid designators return
+  `Error(InvalidEciDesignator(..))`, and non-Standard symbols reject ECI
+  with `Error(IncompatibleOptions(..))`. SVG option setters now normalize
+  invalid dimensions the same way the PNG renderer already did. (#3)
 
 ### Initial
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.1.0] - 2026-05-14
+
 ### Changed
 
 - `package_version_test` now reads `gleam.toml` at test time and asserts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,11 +96,11 @@ Steps for a new release `vX.Y.Z`:
 1. Confirm `main` is green on CI and the working tree is clean.
 2. Promote any items under `## Unreleased` in `CHANGELOG.md` into a
    new `## [X.Y.Z] - YYYY-MM-DD` section directly below `## Unreleased`.
-3. Bump `version = "X.Y.Z"` in `gleam.toml`. The
-   `qrkit.package_version` constant in `src/qrkit.gleam` is
-   cross-checked against this value by `package_version_test` in the
-   test suite, so if you also bump the constant by hand the two stay
-   in lockstep; if you forget, CI fails before publish (#2).
+3. Bump `version = "X.Y.Z"` in `gleam.toml`. The release process treats
+   that file as the metadata source of truth, and
+   `package_version_test` cross-checks `qrkit.package_version` in
+   `src/qrkit.gleam` against it. If you forget to bump the runtime
+   constant, CI fails before publish (#2).
 4. Open a PR with the changelog and version bump, get it green and
    merged.
 5. After merge, fast-forward `main` and tag the merge commit:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pub fn main() {
 
 `qrkit.encode/1` picks the smallest version that fits and defaults to ECC level Medium. The returned `QrCode` is opaque — use the renderers in `qrkit/render/*` to turn it into pixels.
 
-## Builder for ECC, version, and ECI
+## Builder for ECC, exact version, and ECI
 
 ```gleam
 import qrkit
@@ -45,14 +45,14 @@ pub fn high_density_qr() -> qrkit.QrCode {
   let assert Ok(qr) =
     qrkit.new("https://github.com/sponsors/nao1215")
     |> qrkit.with_ecc(types.Quartile)
-    |> qrkit.with_min_version(4)
+    |> qrkit.with_exact_version(4)
     |> qrkit.with_eci(26)
     |> qrkit.build()
   qr
 }
 ```
 
-`with_ecc` selects an error correction level, `with_min_version` pins the symbol version (the build returns `Error(DataExceedsCapacity)` or `Error(IncompatibleOptions)` if the payload, mode, or ECC level does not fit at that version), and `with_eci` prepends an Extended Channel Interpretation header (26 for UTF-8). When `with_min_version` is omitted, `build` picks the smallest version that fits.
+`with_ecc` selects an error correction level, `with_exact_version` pins the symbol version (the build returns `Error(DataExceedsCapacity)` or `Error(IncompatibleOptions)` if the payload, mode, or ECC level does not fit at that version), and `with_eci` prepends an Extended Channel Interpretation header (26 for UTF-8). ECI is available on Standard QR only, and invalid designators surface as `Error(InvalidEciDesignator(..))`. When no exact version is configured, `build` picks the smallest version that fits. `with_min_version` is kept as a compatibility alias for older callers.
 
 ## Render as SVG for the browser
 
@@ -217,7 +217,7 @@ import qrkit/content
 
 pub fn meeting_qr() -> Result(qrkit.QrCode, qrkit.EncodeError) {
   // 2026-05-14 10:00 UTC, ends 11:00 UTC.
-  content.event(title: "Sync", start_unix: 1_778_745_600, end_unix: 1_778_749_200)
+  content.event(title: "Sync", start_unix: 1_778_752_800, end_unix: 1_778_756_400)
   |> content.with_location("Online")
   |> content.with_description("Project sync meeting")
   |> content.event_to_string
@@ -234,11 +234,12 @@ import qrkit
 import qrkit/types
 
 pub fn describe(qr: qrkit.QrCode) -> #(Int, Int, String, Bool) {
+  let assert Ok(top_left) = qrkit.module_at(qr, 0, 0)
   #(
     qrkit.version(qr),
     qrkit.size(qr),
     qrkit.error_correction_designator(qrkit.error_correction(qr)),
-    qrkit.module_at(qr, 0, 0),
+    top_left,
   )
 }
 
@@ -248,7 +249,7 @@ pub fn ecc_letter_for_quartile() -> String {
 }
 ```
 
-`qrkit.rows/1` returns the matrix as `List(List(Bool))` for custom renderers.
+`qrkit.rows/1` returns the matrix as `List(List(Bool))` for custom renderers. `qrkit.module_at/3` returns `Error(ModuleOutOfBounds(..))` for invalid coordinates instead of silently treating them as light modules.
 
 ## Micro QR
 
@@ -263,7 +264,7 @@ pub fn business_card_qr() -> String {
   let assert Ok(qr) =
     qrkit.new("01234567")
     |> qrkit.with_symbol(types.Micro)
-    |> qrkit.with_min_version(2)
+    |> qrkit.with_exact_version(2)
     |> qrkit.with_ecc(types.Low)
     |> qrkit.build()
 
@@ -333,10 +334,11 @@ pub fn raw_byte_qr() -> Result(qrkit.QrCode, qrkit.EncodeError) {
 
 ## Errors
 
-Every public entry point returns `Result(_, qrkit.EncodeError)`. The variants live in `qrkit/error` and are:
+Every public encoding entry point returns `Result(_, qrkit.EncodeError)`. The variants live in `qrkit/error` and are:
 
 - `EmptyInput` — empty `data`.
 - `InvalidVersion(requested)` — version outside the symbol family.
+- `InvalidEciDesignator(designator)` — ECI assignment number outside `0..999999`.
 - `DataExceedsCapacity(bits_needed, bits_available)` — payload does not fit.
 - `UnsupportedCharacter(at_index, character)` — a character the chosen mode cannot encode.
 - `IncompatibleOptions(reason)` — combination not allowed (for example, rMQR with Low ECC).
@@ -374,7 +376,7 @@ Full API reference: <https://hexdocs.pm/qrkit/>.
 - `qrkit` does not sanity-check the payload — if you stuff `javascript:` URIs, otpauth secrets, or attacker-controlled text into a QR, the receiving app will get exactly that. Validate before encoding.
 - The SVG renderer escapes caller-supplied `dark_color` / `light_color` values so a hostile colour cannot break out of the `fill="..."` attribute. That is the only escaping it performs; the surrounding `<svg>` document is not a sanitiser. Treat the output as untrusted markup when embedding it into arbitrary HTML, and pass it through a sanitiser such as DOMPurify on that boundary.
 - The library writes payload data into the matrix as-is. `EncodeError` variants never contain the input payload except for `UnsupportedCharacter`, which reports the single offending character; if that is a privacy concern (e.g., the QR carried a TOTP secret) handle the error before logging.
-- Every public entry point returns `Result(_, EncodeError)`. Invalid or unsupported input surfaces as a typed error variant (`DataExceedsCapacity`, `InvalidVersion`, …) rather than a runtime crash.
+- Every public encoding entry point returns `Result(_, EncodeError)`. Invalid or unsupported input surfaces as a typed error variant (`DataExceedsCapacity`, `InvalidVersion`, …) rather than a runtime crash.
 
 ## License
 

--- a/src/qrkit.gleam
+++ b/src/qrkit.gleam
@@ -31,9 +31,14 @@ pub type Symbol =
   types.Symbol
 
 /// Type alias for [`qrkit/error.EncodeError`](./qrkit/error.html#EncodeError).
-/// To pattern-match on `EmptyInput | InvalidVersion(..) | DataExceedsCapacity(..) | UnsupportedCharacter(..) | IncompatibleOptions(..)`, `import qrkit/error`.
+/// To pattern-match on `EmptyInput | InvalidVersion(..) | InvalidEciDesignator(..) | DataExceedsCapacity(..) | UnsupportedCharacter(..) | IncompatibleOptions(..)`, `import qrkit/error`.
 pub type EncodeError =
   error.EncodeError
+
+/// Type alias for [`qrkit/error.MatrixAccessError`](./qrkit/error.html#MatrixAccessError).
+/// To pattern-match on `ModuleOutOfBounds(..)`, `import qrkit/error`.
+pub type MatrixAccessError =
+  error.MatrixAccessError
 
 pub opaque type Builder {
   Builder(
@@ -79,8 +84,7 @@ pub fn with_ecc(builder: Builder, ecc: ErrorCorrection) -> Builder {
   Builder(data, ecc, min_version, eci, symbol, preference)
 }
 
-/// Set the minimum symbol version as a **strict floor**: the build will use
-/// exactly this version, not silently promote to a larger one.
+/// Pin the symbol version exactly.
 ///
 /// The value is interpreted relative to the active symbol family: Standard QR
 /// accepts 1..40, Micro QR accepts 1..4 (M1..M4), and rMQR accepts 1..32
@@ -88,15 +92,27 @@ pub fn with_ecc(builder: Builder, ecc: ErrorCorrection) -> Builder {
 ///
 /// If the payload, mode, or ECC level cannot be satisfied at the requested
 /// version, `build` returns `Error(DataExceedsCapacity)` or
-/// `Error(IncompatibleOptions)` instead of bumping to a larger version. When
-/// `with_min_version` is not called, the encoder selects the smallest version
-/// that fits the payload (the original "smallest fit" default).
-pub fn with_min_version(builder: Builder, min_version: Int) -> Builder {
+/// `Error(IncompatibleOptions)` instead of bumping to a larger version.
+/// When no exact version is configured, the encoder selects the smallest
+/// version that fits the payload.
+pub fn with_exact_version(builder: Builder, version: Int) -> Builder {
   let Builder(data, ecc, _, eci, symbol, preference) = builder
-  Builder(data, ecc, Some(min_version), eci, symbol, preference)
+  Builder(data, ecc, Some(version), eci, symbol, preference)
+}
+
+/// Compatibility alias for [`with_exact_version`](#with_exact_version).
+///
+/// Despite the historical name, this pins the symbol version exactly rather
+/// than setting a lower bound. New code should prefer `with_exact_version`.
+pub fn with_min_version(builder: Builder, min_version: Int) -> Builder {
+  with_exact_version(builder, min_version)
 }
 
 /// Add an optional ECI assignment designator before the data segments.
+///
+/// ECI is only supported for Standard QR. Valid designators are in the range
+/// 0..999999; invalid values surface as `Error(InvalidEciDesignator(..))`
+/// during `build`.
 pub fn with_eci(builder: Builder, designator: Int) -> Builder {
   let Builder(data, ecc, min_version, _, symbol, preference) = builder
   Builder(data, ecc, min_version, Some(designator), symbol, preference)
@@ -123,7 +139,7 @@ pub fn build(builder: Builder) -> Result(QrCode, EncodeError) {
   case data == "" {
     True -> Error(error.EmptyInput)
     False ->
-      case validate_min_version(min_version, symbol) {
+      case validate_builder_options(min_version, eci, symbol) {
         Error(error) -> Error(error)
         Ok(Nil) ->
           case symbol {
@@ -174,6 +190,17 @@ pub fn build(builder: Builder) -> Result(QrCode, EncodeError) {
   }
 }
 
+fn validate_builder_options(
+  min_version: Option(Int),
+  eci: Option(Int),
+  symbol: Symbol,
+) -> Result(Nil, EncodeError) {
+  case validate_min_version(min_version, symbol) {
+    Error(error) -> Error(error)
+    Ok(Nil) -> validate_eci(eci, symbol)
+  }
+}
+
 fn validate_min_version(
   min_version: Option(Int),
   symbol: Symbol,
@@ -191,6 +218,24 @@ fn validate_min_version(
         False -> Ok(Nil)
       }
     }
+  }
+}
+
+fn validate_eci(eci: Option(Int), symbol: Symbol) -> Result(Nil, EncodeError) {
+  case eci {
+    None -> Ok(Nil)
+    Some(designator) ->
+      case designator < 0 || designator > 999_999 {
+        True -> Error(error.InvalidEciDesignator(designator))
+        False ->
+          case symbol == types.Standard {
+            True -> Ok(Nil)
+            False ->
+              Error(error.IncompatibleOptions(
+                "ECI is only supported for Standard QR",
+              ))
+          }
+      }
   }
 }
 
@@ -294,14 +339,17 @@ pub fn mask(qr: QrCode) -> Int {
 }
 
 /// Return a single module from the symbol matrix.
-pub fn module_at(qr: QrCode, x: Int, y: Int) -> Bool {
+///
+/// Returns `Error(ModuleOutOfBounds(..))` when `x` or `y` fall outside the
+/// matrix dimensions.
+pub fn module_at(qr: QrCode, x: Int, y: Int) -> Result(Bool, MatrixAccessError) {
   case rows(qr) |> util.at(y) {
     Ok(row) ->
       case util.at(row, x) {
-        Ok(value) -> value
-        Error(_) -> False
+        Ok(value) -> Ok(value)
+        Error(_) -> Error(error.ModuleOutOfBounds(x, y, width(qr), height(qr)))
       }
-    Error(_) -> False
+    Error(_) -> Error(error.ModuleOutOfBounds(x, y, width(qr), height(qr)))
   }
 }
 

--- a/src/qrkit/content.gleam
+++ b/src/qrkit/content.gleam
@@ -5,6 +5,7 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
+import gleam/uri
 
 /// Return a URL payload unchanged.
 pub fn url(href: String) -> String {
@@ -105,14 +106,14 @@ pub fn vcard_to_string(card: VCard) -> String {
   [
     Some("BEGIN:VCARD"),
     Some("VERSION:3.0"),
-    option_line("N", name),
-    option_line("FN", name),
-    option_line("ORG", organization),
-    option_line("TITLE", title),
-    option_line("TEL", phone),
-    option_line("EMAIL", email),
-    option_line("URL", url),
-    option_line("ADR", address),
+    option_line_with("N", name, escape_vcard),
+    option_line_with("FN", name, escape_vcard),
+    option_line_with("ORG", organization, escape_vcard),
+    option_line_with("TITLE", title, escape_vcard),
+    option_line_with("TEL", phone, escape_vcard),
+    option_line_with("EMAIL", email, escape_vcard),
+    option_line_with("URL", url, escape_vcard),
+    option_line_with("ADR", address, escape_vcard),
     Some("END:VCARD"),
   ]
   |> present_lines([])
@@ -128,9 +129,9 @@ pub fn email(
   "mailto:"
   <> to
   <> "?subject="
-  <> url_encode(subject)
+  <> percent_encode(subject)
   <> "&body="
-  <> url_encode(body)
+  <> percent_encode(body)
 }
 
 /// Build an SMS payload.
@@ -209,8 +210,8 @@ pub fn event_to_string(event: CalendarEvent) -> String {
     Some("SUMMARY:" <> escape_ical(title)),
     Some(start_key <> ":" <> start_value),
     Some(end_key <> ":" <> end_value),
-    option_line("LOCATION", location),
-    option_line("DESCRIPTION", description),
+    option_line_with("LOCATION", location, escape_ical),
+    option_line_with("DESCRIPTION", description, escape_ical),
     Some("END:VEVENT"),
     Some("END:VCALENDAR"),
   ]
@@ -240,9 +241,13 @@ fn escape_wifi(value: String) -> String {
   |> string.replace(each: "\"", with: "\\\"")
 }
 
-fn option_line(key: String, value: Option(String)) -> Option(String) {
+fn option_line_with(
+  key: String,
+  value: Option(String),
+  escape: fn(String) -> String,
+) -> Option(String) {
   case value {
-    Some(value) -> Some(key <> ":" <> value)
+    Some(value) -> Some(key <> ":" <> escape(value))
     None -> None
   }
 }
@@ -255,10 +260,16 @@ fn present_lines(lines: List(Option(String)), acc: List(String)) -> List(String)
   }
 }
 
-fn url_encode(value: String) -> String {
+fn percent_encode(value: String) -> String {
+  uri.percent_encode(value)
+}
+
+fn escape_vcard(value: String) -> String {
   value
-  |> string.replace(each: " ", with: "%20")
-  |> string.replace(each: "\n", with: "%0A")
+  |> string.replace(each: "\\", with: "\\\\")
+  |> string.replace(each: "\n", with: "\\n")
+  |> string.replace(each: ",", with: "\\,")
+  |> string.replace(each: ";", with: "\\;")
 }
 
 fn escape_ical(value: String) -> String {

--- a/src/qrkit/error.gleam
+++ b/src/qrkit/error.gleam
@@ -4,7 +4,13 @@
 pub type EncodeError {
   DataExceedsCapacity(bits_needed: Int, bits_available: Int)
   InvalidVersion(requested: Int)
+  InvalidEciDesignator(designator: Int)
   UnsupportedCharacter(at_index: Int, character: String)
   EmptyInput
   IncompatibleOptions(reason: String)
+}
+
+/// Errors returned while reading individual modules from a QR matrix.
+pub type MatrixAccessError {
+  ModuleOutOfBounds(x: Int, y: Int, width: Int, height: Int)
 }

--- a/src/qrkit/internal/micro.gleam
+++ b/src/qrkit/internal/micro.gleam
@@ -71,11 +71,12 @@ const format_info_table: List(Int) = [
 
 /// Encode `text` into a Micro QR code.
 ///
-/// `requested_version` is `Some(N)` when the caller explicitly asked for a
-/// floor via `qrkit.with_min_version(N)`, in which case the encoder uses N
-/// as a strict version (any mode/ECC/capacity mismatch surfaces as an
-/// `Error`). When `requested_version` is `None`, the encoder picks the
-/// smallest version that fits the payload.
+/// `requested_version` is `Some(N)` when the caller explicitly pinned the
+/// version via `qrkit.with_exact_version(N)` (or the legacy
+/// `with_min_version(N)` alias), in which case the encoder uses N as a strict
+/// version (any mode/ECC/capacity mismatch surfaces as an `Error`). When
+/// `requested_version` is `None`, the encoder picks the smallest version that
+/// fits the payload.
 pub fn encode(
   text: String,
   ecc: ErrorCorrection,

--- a/src/qrkit/internal/rmqr.gleam
+++ b/src/qrkit/internal/rmqr.gleam
@@ -127,10 +127,11 @@ const alignment_columns: List(Int) = [
 /// Encode `text` into an rMQR symbol.
 ///
 /// `requested_version` is `Some(N)` (1-based, 1 = R7×43, 32 = R17×139) when
-/// the caller explicitly asked for a floor via `qrkit.with_min_version(N)`;
-/// in that case the encoder uses N as a strict version (capacity overflow
-/// at N returns `Error` instead of promoting to N+1). When `requested_version`
-/// is `None`, the encoder picks the smallest version that fits.
+/// the caller explicitly pinned the version via `qrkit.with_exact_version(N)`
+/// (or the legacy `with_min_version(N)` alias); in that case the encoder uses
+/// N as a strict version (capacity overflow at N returns `Error` instead of
+/// promoting to N+1). When `requested_version` is `None`, the encoder picks
+/// the smallest version that fits.
 pub fn encode(
   text: String,
   ecc: ErrorCorrection,

--- a/src/qrkit/internal/segment.gleam
+++ b/src/qrkit/internal/segment.gleam
@@ -2,7 +2,7 @@
 
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import qrkit/error.{type EncodeError}
+import qrkit/error.{type EncodeError, InvalidEciDesignator}
 import qrkit/internal/bitstream
 import qrkit/internal/mode
 import qrkit/internal/util
@@ -255,8 +255,8 @@ fn append_eci(
   stream: bitstream.BitStream,
   designator: Int,
 ) -> Result(bitstream.BitStream, EncodeError) {
-  case designator < 0 {
-    True -> Ok(stream)
+  case designator < 0 || designator > 999_999 {
+    True -> Error(InvalidEciDesignator(designator))
     False ->
       case designator < 128 {
         True ->

--- a/src/qrkit/internal/standard.gleam
+++ b/src/qrkit/internal/standard.gleam
@@ -27,8 +27,9 @@ pub opaque type Encoded {
 
 /// Encode `text` as a Standard QR code.
 ///
-/// `min_version` is `Some(N)` when the caller explicitly asked for a floor
-/// via `qrkit.with_min_version(N)`; in that case the encoder uses N as a
+/// `min_version` is `Some(N)` when the caller explicitly pinned the version
+/// via `qrkit.with_exact_version(N)` (or the legacy `with_min_version(N)`
+/// alias); in that case the encoder uses N as a
 /// strict version (a capacity overflow at N returns `Error` instead of
 /// promoting to a larger version). When `min_version` is `None`, the
 /// encoder picks the smallest version in 1..40 that fits the payload.

--- a/src/qrkit/render/png.gleam
+++ b/src/qrkit/render/png.gleam
@@ -12,6 +12,9 @@ const crc32_polynomial = 0xEDB88320
 const adler32_modulus = 65_521
 
 /// Render a QR code as PNG bytes.
+///
+/// `scale` values less than 1 are normalised to 1, and negative `margin`
+/// values are normalised to 0.
 pub fn to_bit_array(
   qr: qrkit.QrCode,
   scale scale: Int,

--- a/src/qrkit/render/svg.gleam
+++ b/src/qrkit/render/svg.gleam
@@ -21,15 +21,31 @@ pub fn default_options() -> SvgOptions {
 }
 
 /// Set the SVG module size.
+///
+/// Values less than 1 are normalised to 1 to keep the rendered output usable.
 pub fn with_module_size(options: SvgOptions, px: Int) -> SvgOptions {
   let SvgOptions(_, margin, dark_color, light_color, background) = options
-  SvgOptions(px, margin, dark_color, light_color, background)
+  SvgOptions(
+    positive_or(px, default: 1),
+    margin,
+    dark_color,
+    light_color,
+    background,
+  )
 }
 
 /// Set the quiet-zone margin in modules.
+///
+/// Negative values are normalised to 0.
 pub fn with_margin(options: SvgOptions, modules: Int) -> SvgOptions {
   let SvgOptions(module_size, _, dark_color, light_color, background) = options
-  SvgOptions(module_size, modules, dark_color, light_color, background)
+  SvgOptions(
+    module_size,
+    non_negative_or(modules, default: 0),
+    dark_color,
+    light_color,
+    background,
+  )
 }
 
 /// Set the dark module colour.
@@ -154,5 +170,19 @@ fn dark_run_length(row: List(Bool), count: Int) -> Int {
   case row {
     [True, ..rest] -> dark_run_length(rest, count + 1)
     _ -> count
+  }
+}
+
+fn positive_or(value: Int, default default: Int) -> Int {
+  case value > 0 {
+    True -> value
+    False -> default
+  }
+}
+
+fn non_negative_or(value: Int, default default: Int) -> Int {
+  case value >= 0 {
+    True -> value
+    False -> default
   }
 }

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -19,10 +19,11 @@ pub fn main() -> Nil {
 }
 
 pub fn package_version_test() -> Nil {
-  // Cross-check the runtime-visible version against the single source
-  // of truth (`gleam.toml`). When a release bumps `gleam.toml` but
-  // forgets to bump `qrkit.package_version`, this test fails CI
-  // immediately rather than letting drift ship to Hex. See #2.
+  // Treat `gleam.toml` as the release metadata source of truth and
+  // cross-check the runtime-visible version against it. When a release
+  // bumps `gleam.toml` but forgets to bump `qrkit.package_version`,
+  // this test fails CI immediately rather than letting drift ship to
+  // Hex. See #2.
   let assert Ok(toml) = simplifile.read("gleam.toml")
   let assert Ok(version_in_toml) = extract_toml_version(toml)
   qrkit.package_version()
@@ -46,6 +47,11 @@ fn extract_toml_version(toml: String) -> Result(String, Nil) {
       Error(_) -> Error(Nil)
     }
   })
+}
+
+fn must_module_at(qr: qrkit.QrCode, x: Int, y: Int) -> Bool {
+  let assert Ok(value) = qrkit.module_at(qr, x, y)
+  value
 }
 
 pub fn encode_returns_square_symbol_test() -> Nil {
@@ -126,6 +132,41 @@ pub fn vcard_content_helper_test() -> Nil {
   )
 }
 
+pub fn email_content_percent_encodes_reserved_chars_test() -> Nil {
+  content.email(
+    to: "you@example.com",
+    subject: "status & next?",
+    body: "100% ready = yes\nship it",
+  )
+  |> should.equal(
+    "mailto:you@example.com?subject=status%20%26%20next%3F&body=100%25%20ready%20%3D%20yes%0Aship%20it",
+  )
+}
+
+pub fn vcard_escapes_reserved_chars_test() -> Nil {
+  content.vcard()
+  |> content.with_name("Nao;Inc,\nDev")
+  |> content.with_address("Tokyo;JP,\nLine2")
+  |> content.vcard_to_string()
+  |> should.equal(
+    "BEGIN:VCARD\nVERSION:3.0\nN:Nao\\;Inc\\,\\nDev\nFN:Nao\\;Inc\\,\\nDev\nADR:Tokyo\\;JP\\,\\nLine2\nEND:VCARD",
+  )
+}
+
+pub fn calendar_event_escapes_text_fields_test() -> Nil {
+  content.event(
+    title: "Sync;One,Two",
+    start_unix: 1_778_752_800,
+    end_unix: 1_778_756_400,
+  )
+  |> content.with_location("Room;A,\nTokyo")
+  |> content.with_description("Line1\nLine2;done,ok")
+  |> content.event_to_string()
+  |> should.equal(
+    "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Sync\\;One\\,Two\nDTSTART:20260514T100000Z\nDTEND:20260514T110000Z\nLOCATION:Room\\;A\\,\\nTokyo\nDESCRIPTION:Line1\\nLine2\\;done\\,ok\nEND:VEVENT\nEND:VCALENDAR",
+  )
+}
+
 pub fn ascii_renderer_test() -> Nil {
   let assert Ok(qr) = qrkit.encode("HELLO WORLD")
   ascii.to_string(qr)
@@ -146,11 +187,11 @@ pub fn svg_renderer_test() -> Nil {
 pub fn hello_world_has_finder_patterns_test() -> Nil {
   let assert Ok(qr) = qrkit.encode("HELLO WORLD")
   should.equal(qrkit.version(qr), 1)
-  should.equal(qrkit.module_at(qr, 0, 0), True)
-  should.equal(qrkit.module_at(qr, 6, 0), True)
-  should.equal(qrkit.module_at(qr, 0, 6), True)
-  should.equal(qrkit.module_at(qr, 20, 0), True)
-  should.equal(qrkit.module_at(qr, 0, 20), True)
+  should.equal(must_module_at(qr, 0, 0), True)
+  should.equal(must_module_at(qr, 6, 0), True)
+  should.equal(must_module_at(qr, 0, 6), True)
+  should.equal(must_module_at(qr, 20, 0), True)
+  should.equal(must_module_at(qr, 0, 20), True)
 }
 
 pub fn hello_world_matches_reference_matrix_test() -> Nil {
@@ -310,14 +351,14 @@ pub fn v7_decodes_to_input_text_test() -> Nil {
   |> should.equal(45)
 
   // Centre alignment (22, 22) must be dark.
-  qrkit.module_at(qr, 22, 22)
+  must_module_at(qr, 22, 22)
   |> should.equal(True)
   // Off-centre alignment-pattern corners around (22, 22) — the 5x5 pattern
   // has dark outer ring + light interior + dark centre, so (20, 22) (top
   // edge of the pattern) is dark, (21, 22) (one inside) is light.
-  qrkit.module_at(qr, 22, 20)
+  must_module_at(qr, 22, 20)
   |> should.equal(True)
-  qrkit.module_at(qr, 22, 21)
+  must_module_at(qr, 22, 21)
   |> should.equal(False)
 }
 
@@ -348,7 +389,7 @@ pub fn micro_qr_m1_half_codeword_test() -> Nil {
   |> should.equal(11)
   qrkit.height(qr)
   |> should.equal(11)
-  qrkit.module_at(qr, 0, 0)
+  must_module_at(qr, 0, 0)
   |> should.equal(True)
 }
 
@@ -420,7 +461,7 @@ pub fn rmqr_r7x43_default_test() -> Nil {
   |> should.equal(7)
   qrkit.symbol(qr)
   |> should.equal(types.Rectangular)
-  qrkit.module_at(qr, 0, 0)
+  must_module_at(qr, 0, 0)
   |> should.equal(True)
 }
 
@@ -646,23 +687,33 @@ pub fn reserved_areas_intact_at_v25_test() -> Nil {
   |> should.equal(25)
 
   // All three finder pattern corners are 7x7 squares with dark outer rings.
-  qrkit.module_at(qr, 0, 0) |> should.be_true
-  qrkit.module_at(qr, 6, 0) |> should.be_true
-  qrkit.module_at(qr, 110, 0) |> should.be_true
-  qrkit.module_at(qr, 116, 0) |> should.be_true
-  qrkit.module_at(qr, 0, 110) |> should.be_true
-  qrkit.module_at(qr, 0, 116) |> should.be_true
+  must_module_at(qr, 0, 0) |> should.be_true
+  must_module_at(qr, 6, 0) |> should.be_true
+  must_module_at(qr, 110, 0) |> should.be_true
+  must_module_at(qr, 116, 0) |> should.be_true
+  must_module_at(qr, 0, 110) |> should.be_true
+  must_module_at(qr, 0, 116) |> should.be_true
 
   // The always-dark module at (8, 4 * version + 9) — ISO/IEC 18004 §6.9.
-  qrkit.module_at(qr, 8, 109)
+  must_module_at(qr, 8, 109)
   |> should.be_true
 
   // Timing pattern at row 6 / col 6 alternates dark/light starting dark.
-  qrkit.module_at(qr, 8, 6) |> should.be_true
-  qrkit.module_at(qr, 9, 6) |> should.be_false
-  qrkit.module_at(qr, 10, 6) |> should.be_true
-  qrkit.module_at(qr, 6, 8) |> should.be_true
-  qrkit.module_at(qr, 6, 9) |> should.be_false
+  must_module_at(qr, 8, 6) |> should.be_true
+  must_module_at(qr, 9, 6) |> should.be_false
+  must_module_at(qr, 10, 6) |> should.be_true
+  must_module_at(qr, 6, 8) |> should.be_true
+  must_module_at(qr, 6, 9) |> should.be_false
+}
+
+pub fn module_at_out_of_bounds_errors_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  qrkit.module_at(qr, -1, 0)
+  |> should.equal(Error(error.ModuleOutOfBounds(-1, 0, 21, 21)))
+  qrkit.module_at(qr, 21, 0)
+  |> should.equal(Error(error.ModuleOutOfBounds(21, 0, 21, 21)))
+  qrkit.module_at(qr, 0, 21)
+  |> should.equal(Error(error.ModuleOutOfBounds(0, 21, 21, 21)))
 }
 
 // ---------------------------------------------------------------------------
@@ -728,14 +779,50 @@ pub fn payload_exceeds_v40_capacity_errors_test() -> Nil {
   }
 }
 
+pub fn negative_eci_designator_errors_test() -> Nil {
+  qrkit.new("HELLO")
+  |> qrkit.with_eci(-1)
+  |> qrkit.build()
+  |> should.equal(Error(error.InvalidEciDesignator(-1)))
+}
+
+pub fn oversized_eci_designator_errors_test() -> Nil {
+  qrkit.new("HELLO")
+  |> qrkit.with_eci(1_000_000)
+  |> qrkit.build()
+  |> should.equal(Error(error.InvalidEciDesignator(1_000_000)))
+}
+
+pub fn eci_is_rejected_for_micro_qr_test() -> Nil {
+  let result =
+    qrkit.new("12345")
+    |> qrkit.with_symbol(types.Micro)
+    |> qrkit.with_eci(26)
+    |> qrkit.build()
+  case result {
+    Error(error.IncompatibleOptions(_)) -> Nil
+    _ -> should.fail()
+  }
+}
+
 // ---------------------------------------------------------------------------
-// `with_min_version` is a strict floor.
+// `with_exact_version` is the preferred exact-version API, and
+// `with_min_version` remains a compatibility alias for the same behaviour.
 //
-// When the caller passes `with_min_version(N)`, the builder must use exactly
-// version N — capacity overflow, mode incompatibility, or ECC incompatibility
-// at N must surface as a typed `Error`, not silently promote to N+1. Tests
-// below pin each of those error paths.
+// When the caller pins version N, the builder must use exactly version N —
+// capacity overflow, mode incompatibility, or ECC incompatibility at N must
+// surface as a typed `Error`, not silently promote to N+1. Tests below pin
+// each of those error paths.
 // ---------------------------------------------------------------------------
+
+pub fn exact_version_pins_exact_version_test() -> Nil {
+  let assert Ok(qr) =
+    qrkit.new("HI")
+    |> qrkit.with_exact_version(5)
+    |> qrkit.build
+  qrkit.version(qr)
+  |> should.equal(5)
+}
 
 pub fn strict_standard_overflow_at_min_version_errors_test() -> Nil {
   // v1 ECC-M Alphanumeric capacity is 20 chars. 100 chars cannot fit at v1,
@@ -816,9 +903,7 @@ pub fn strict_rmqr_overflow_errors_test() -> Nil {
 }
 
 pub fn strict_min_version_pins_exact_version_test() -> Nil {
-  // A payload that fits at v1 but the caller asks for v5 must produce v5,
-  // not v1 — the floor is honoured even when the payload would otherwise
-  // fit at a smaller version.
+  // Legacy alias coverage: `with_min_version` still pins the version exactly.
   let assert Ok(qr) =
     qrkit.new("HI")
     |> qrkit.with_min_version(5)
@@ -862,6 +947,18 @@ pub fn svg_dark_color_escaped_test() -> Nil {
   |> should.be_true
 }
 
+pub fn svg_dimension_options_normalize_invalid_values_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let options =
+    svg.default_options()
+    |> svg.with_module_size(0)
+    |> svg.with_margin(-3)
+  let document = svg.to_string(qr, options)
+
+  string.contains(does: document, contain: "viewBox=\"0 0 21 21\"")
+  |> should.be_true
+}
+
 pub fn png_renderer_test() -> Nil {
   let assert Ok(qr) = qrkit.encode("HELLO WORLD")
   let image = png.to_bit_array(qr, scale: 2, margin: 4)
@@ -876,6 +973,14 @@ pub fn png_renderer_test() -> Nil {
   let assert Ok(dimensions) = bit_array.slice(image, at: 16, take: 8)
   dimensions
   |> should.equal(<<0, 0, 0, 58, 0, 0, 0, 58>>)
+}
+
+pub fn png_renderer_normalizes_invalid_scale_and_margin_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let normalized = png.to_bit_array(qr, scale: 1, margin: 0)
+  let coerced = png.to_bit_array(qr, scale: 0, margin: -4)
+  coerced
+  |> should.equal(normalized)
 }
 
 fn rows_to_strings(rows: List(List(Bool))) -> List(String) {

--- a/test/readme_examples_test.gleam
+++ b/test/readme_examples_test.gleam
@@ -38,7 +38,7 @@ fn readme_high_density_qr() -> qrkit.QrCode {
   let assert Ok(qr) =
     qrkit.new("https://github.com/sponsors/nao1215")
     |> qrkit.with_ecc(types.Quartile)
-    |> qrkit.with_min_version(4)
+    |> qrkit.with_exact_version(4)
     |> qrkit.with_eci(26)
     |> qrkit.build()
   qr
@@ -48,7 +48,7 @@ pub fn readme_high_density_qr_test() -> Nil {
   let qr = readme_high_density_qr()
   qrkit.error_correction(qr)
   |> should.equal(types.Quartile)
-  // with_min_version is now a strict floor; we asked for v4 and must get v4.
+  // with_exact_version pins the symbol version.
   qrkit.version(qr)
   |> should.equal(4)
 }
@@ -214,8 +214,8 @@ pub fn readme_content_helpers_test() -> Nil {
 fn readme_meeting_qr() -> Result(qrkit.QrCode, qrkit.EncodeError) {
   content.event(
     title: "Sync",
-    start_unix: 1_778_745_600,
-    end_unix: 1_778_749_200,
+    start_unix: 1_778_752_800,
+    end_unix: 1_778_756_400,
   )
   |> content.with_location("Online")
   |> content.with_description("Project sync meeting")
@@ -228,16 +228,31 @@ pub fn readme_meeting_qr_test() -> Nil {
   Nil
 }
 
+pub fn readme_meeting_qr_payload_matches_documented_times_test() -> Nil {
+  content.event(
+    title: "Sync",
+    start_unix: 1_778_752_800,
+    end_unix: 1_778_756_400,
+  )
+  |> content.with_location("Online")
+  |> content.with_description("Project sync meeting")
+  |> content.event_to_string
+  |> should.equal(
+    "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Sync\nDTSTART:20260514T100000Z\nDTEND:20260514T110000Z\nLOCATION:Online\nDESCRIPTION:Project sync meeting\nEND:VEVENT\nEND:VCALENDAR",
+  )
+}
+
 // ---------------------------------------------------------------------------
 // README: Inspect the matrix
 // ---------------------------------------------------------------------------
 
 fn readme_describe(qr: qrkit.QrCode) -> #(Int, Int, String, Bool) {
+  let assert Ok(top_left) = qrkit.module_at(qr, 0, 0)
   #(
     qrkit.version(qr),
     qrkit.size(qr),
     qrkit.error_correction_designator(qrkit.error_correction(qr)),
-    qrkit.module_at(qr, 0, 0),
+    top_left,
   )
 }
 
@@ -265,7 +280,7 @@ fn readme_business_card_qr() -> String {
   let assert Ok(qr) =
     qrkit.new("01234567")
     |> qrkit.with_symbol(types.Micro)
-    |> qrkit.with_min_version(2)
+    |> qrkit.with_exact_version(2)
     |> qrkit.with_ecc(types.Low)
     |> qrkit.build()
 


### PR DESCRIPTION
## Summary
Tighten the qrkit public API contracts around payload helpers, exact-version selection, ECI validation, and matrix access.
Prepare the changelog for the v0.1.0 release by moving the pending notes under a dated release section.

## Changes
- escape vCard and iCalendar text fields consistently and percent-encode mailto query parameters
- add with_exact_version, explicit ECI validation, and typed module_at out-of-bounds errors
- normalize invalid SVG dimension inputs, document PNG normalization, and update README/examples/tests
- add the v0.1.0 changelog section for release automation

## Design Decisions
- keep with_min_version as a compatibility alias while steering new callers to with_exact_version
- fail explicitly for invalid ECI and matrix coordinates so callers can detect mistakes instead of getting silent coercion

## Limitations
- no release tag is created here; this PR only prepares main for the v0.1.0 release workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `with_exact_version()` builder method to pin exact QR symbol versions
  * Enhanced ECI validation with explicit error handling for invalid designators

* **Bug Fixes**
  * Fixed URI percent-encoding for email query parameters
  * Corrected text escaping in vCard and iCalendar formats
  * SVG and PNG renderers now normalize invalid dimension values

* **Breaking Changes**
  * `module_at()` now returns a structured error result for out-of-bounds coordinates instead of a boolean value

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/qrkit/pull/7)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->