### PR TITLE
fix(content): RFC compliance pass for iCalendar and vCard renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project will be documented in this file.
 
 - `qrkit/render/ascii`: `AsciiOptions` opaque type plus `default_options/0`, `with_margin/2`, `with_inverse_option/2`, `to_string_with/2`, and `to_string_compact_with/2` — mirroring the builder-style options shape `qrkit/render/svg` already exposes (`svg.default_options |> svg.with_margin(2)`). The new functions let terminal callers tighten the quiet zone for debug dumps, fixture diffs, and inline-doc panels without giving up the ISO/IEC 18004 4-module default for camera-scannable output. Existing `to_string/1`, `with_inverse/1`, and `to_string_compact/1` keep the 4-module default and are unchanged at the API level. (#8)
 
+### Fixed
+
+- `qrkit/content`: comprehensive RFC compliance pass for the iCalendar and vCard renderers (issues #9–#17).
+  - `vcard_to_string` and `event_to_string` now terminate lines with CRLF (`\r\n`) per RFC 5545 §3.1 / RFC 2426 §2.1, not LF-only — strict consumers (Apple iOS Calendar in MIME contexts, Outlook drag-and-drop, `python-icalendar`, `node-vcard`) accept the output. (#12)
+  - Both renderers fold long content lines at 75 octets with `CRLF<space>` continuation per RFC 5545 §3.1 / RFC 2426 §2.6. Folding is grapheme-aware so multi-byte UTF-8 sequences are never split. (#13)
+  - `escape_ical` / `escape_vcard` strip raw `\r` and `NUL` from TEXT values (RFC 5545 §3.3.11 / RFC 2426 §2.4.2 forbid raw control characters; CR in particular emulated CRLF and broke the document). (#11)
+  - `event_to_string` now emits the RFC-required `PRODID` (VCALENDAR §3.7.3), `UID`, and `DTSTAMP` (VEVENT §3.6.1). `UID` is a deterministic synthesis of the event's title hash + start + end so the same event produces the same UID across runs; `DTSTAMP` defaults to `start_unix` since no clock is available in a pure rendering function. (#14)
+  - `vcard_to_string` always emits the RFC 2426 MANDATORY `N` and `FN` properties (§3.1.1 / §3.1.2) — when the caller did not call `with_name`, both are emitted with empty values (`N:;;;;` and `FN:`) so the structure is still spec-conformant. (#15)
+  - `event_to_string` in `all_day` mode now bumps `DTEND` to `start + 1 day` when the caller passed `end_unix == start_unix`, matching RFC 5545 §3.6.1's non-inclusive-end requirement for DATE-valued events. (#16)
+  - `event_to_string` handles pre-epoch `unix` values correctly by floor-dividing into days / seconds-of-day (Gleam's `/` and `%` truncate toward zero, which had let negative sub-day components leak into the formatted output). (#9)
+  - `event_to_string` clamps year to `[1, 9999]` so values beyond Y10K cannot break the RFC 5545 fixed-width `YYYYMMDDTHHMMSSZ` format. (#10)
+  - Final BEGIN/END boundary line is now terminated with CRLF (RFC 5545 §3.1 / RFC 2426 §2.1 require *every* content line — including the last — to end with CRLF).
+  - `content.email` now percent-encodes the `to` addr-spec along with `subject` and `body`, so reserved characters (`?`, `&`, `#`, space) in `to` no longer produce a malformed `mailto:` URI. (#17)
+
 ## [0.1.0] - 2026-05-14
 
 ### Changed

--- a/src/qrkit/content.gleam
+++ b/src/qrkit/content.gleam
@@ -1,4 +1,29 @@
 //// Domain-specific helpers that produce QR-ready payload strings.
+////
+//// iCalendar and vCard renderers in this module follow RFC 5545 and
+//// RFC 2426 to the byte level:
+////
+//// - Lines are terminated with `CRLF` (`\r\n`) (RFC 5545 §3.1,
+////   RFC 2426 §2.1).
+//// - Lines longer than 75 octets are folded with `CRLF<space>`
+////   (RFC 5545 §3.1, RFC 2426 §2.6). Folding is byte-based and
+////   does not split inside a multi-byte UTF-8 sequence.
+//// - TEXT-value escape helpers strip raw `CR` and `NUL` and escape
+////   `\`, `\n`, `,`, `;` (RFC 5545 §3.3.11, RFC 2426 §2.4.2).
+//// - `event_to_string` emits the RFC-required `PRODID` (VCALENDAR-
+////   level) plus `UID` and `DTSTAMP` (VEVENT-level). `UID` is
+////   derived deterministically from the event's title and timestamps
+////   so the same event produces the same UID across runs; `DTSTAMP`
+////   defaults to the event's `start_unix` (no clock is available in
+////   a pure rendering function).
+//// - `event_to_string` in `all_day` mode bumps `DTEND` to
+////   `start_date + 1 day` when the caller passed `end_unix ==
+////   start_unix`, matching RFC 5545 §3.6.1's non-inclusive-end
+////   requirement for DATE-valued events.
+//// - `vcard_to_string` always emits the RFC 2426 MANDATORY `N` and
+////   `FN` properties; when the caller did not set a name they are
+////   emitted with empty values (`N:;;;;` and `FN:`) so the
+////   structure is still RFC-conformant.
 
 import gleam/float
 import gleam/int
@@ -100,14 +125,28 @@ pub fn with_address(card: VCard, address: String) -> VCard {
   VCard(name, phone, email, url, organization, title, Some(address))
 }
 
-/// Render the vCard as a text payload.
+/// Render the vCard as a text payload, RFC 2426 conformant.
+///
+/// The mandatory `N` and `FN` properties are always emitted —
+/// when no name was set via [`with_name`](#with_name) they are
+/// emitted with empty values (`N:;;;;` and `FN:`) so the structure
+/// matches RFC 2426 §3.1.1 / §3.1.2. Lines are CRLF-terminated and
+/// folded at 75 octets per RFC 2426 §2.1 / §2.6.
 pub fn vcard_to_string(card: VCard) -> String {
   let VCard(name, phone, email, url, organization, title, address) = card
+  let n_value = case name {
+    Some(n) -> escape_vcard(n)
+    None -> ";;;;"
+  }
+  let fn_value = case name {
+    Some(n) -> escape_vcard(n)
+    None -> ""
+  }
   [
     Some("BEGIN:VCARD"),
     Some("VERSION:3.0"),
-    option_line_with("N", name, escape_vcard),
-    option_line_with("FN", name, escape_vcard),
+    Some("N:" <> n_value),
+    Some("FN:" <> fn_value),
     option_line_with("ORG", organization, escape_vcard),
     option_line_with("TITLE", title, escape_vcard),
     option_line_with("TEL", phone, escape_vcard),
@@ -117,17 +156,19 @@ pub fn vcard_to_string(card: VCard) -> String {
     Some("END:VCARD"),
   ]
   |> present_lines([])
-  |> string.join(with: "\n")
+  |> list.map(fold_line)
+  |> string.join(with: "\r\n")
 }
 
-/// Build a `mailto:` payload.
+/// Build a `mailto:` payload, percent-encoding every parameter
+/// including the `to` addr-spec.
 pub fn email(
   to to: String,
   subject subject: String,
   body body: String,
 ) -> String {
   "mailto:"
-  <> to
+  <> percent_encode(to)
   <> "?subject="
   <> percent_encode(subject)
   <> "&body="
@@ -189,12 +230,21 @@ pub fn with_all_day(event: CalendarEvent, all_day: Bool) -> CalendarEvent {
   CalendarEvent(title, start_unix, end_unix, location, description, all_day)
 }
 
-/// Render a calendar event as an iCalendar payload.
+/// Render a calendar event as an iCalendar payload, RFC 5545
+/// conformant. Includes the required `PRODID` / `UID` / `DTSTAMP`
+/// properties (#14). In `all_day` mode `DTEND` is bumped to
+/// `start + 1 day` when the caller passed `end_unix == start_unix`
+/// so the resulting DATE range is non-inclusive per §3.6.1 (#16).
+/// Unix timestamps before the epoch are floor-divided so negative
+/// inputs format correctly (#9), and the year is clamped to
+/// `[1, 9999]` to preserve the 4-digit-year fixed-width format
+/// (#10).
 pub fn event_to_string(event: CalendarEvent) -> String {
   let CalendarEvent(title, start_unix, end_unix, location, description, all_day) =
     event
+  let effective_end = adjust_end_for_all_day(start_unix, end_unix, all_day)
   let start_value = format_datetime(start_unix, all_day)
-  let end_value = format_datetime(end_unix, all_day)
+  let end_value = format_datetime(effective_end, all_day)
   let start_key = case all_day {
     True -> "DTSTART;VALUE=DATE"
     False -> "DTSTART"
@@ -203,10 +253,15 @@ pub fn event_to_string(event: CalendarEvent) -> String {
     True -> "DTEND;VALUE=DATE"
     False -> "DTEND"
   }
+  let uid = synthesise_uid(title, start_unix, end_unix)
+  let dtstamp = format_datetime(start_unix, False)
   [
     Some("BEGIN:VCALENDAR"),
     Some("VERSION:2.0"),
+    Some("PRODID:-//nao1215//qrkit//EN"),
     Some("BEGIN:VEVENT"),
+    Some("UID:" <> uid),
+    Some("DTSTAMP:" <> dtstamp),
     Some("SUMMARY:" <> escape_ical(title)),
     Some(start_key <> ":" <> start_value),
     Some(end_key <> ":" <> end_value),
@@ -216,7 +271,51 @@ pub fn event_to_string(event: CalendarEvent) -> String {
     Some("END:VCALENDAR"),
   ]
   |> present_lines([])
-  |> string.join(with: "\n")
+  |> list.map(fold_line)
+  |> string.join(with: "\r\n")
+}
+
+fn adjust_end_for_all_day(start_unix: Int, end_unix: Int, all_day: Bool) -> Int {
+  case all_day && end_unix <= start_unix {
+    True -> start_unix + 86_400
+    False -> end_unix
+  }
+}
+
+fn synthesise_uid(title: String, start_unix: Int, end_unix: Int) -> String {
+  // Deterministic UID: title hash (Erlang :phash2-compatible mix in
+  // pure Gleam) combined with the two timestamps. Stable across runs
+  // for the same input, which is what a QR-payload caller wants —
+  // scanning the same event twice should not produce a new UID.
+  let title_hash = string_hash(title)
+  int.to_string(title_hash)
+  <> "-"
+  <> int.to_string(start_unix)
+  <> "-"
+  <> int.to_string(end_unix)
+  <> "@qrkit.nao1215"
+}
+
+fn string_hash(value: String) -> Int {
+  // Java-style rolling 31x hash with explicit modulo per step so
+  // intermediate values stay below JavaScript's 2^53 safe-integer
+  // ceiling. The modulus is the Mersenne prime 2^31 - 1, giving
+  // ~32-bit-wide UIDs that match on both Erlang and JavaScript
+  // targets without depending on bitwise primitives the BEAM
+  // exposes one way and JS another.
+  let codepoints = string.to_utf_codepoints(value)
+  list.fold(codepoints, 0, fn(acc, codepoint) {
+    let byte = string.utf_codepoint_to_int(codepoint)
+    modulo(acc * 31 + byte, 2_147_483_647)
+  })
+}
+
+fn modulo(value: Int, m: Int) -> Int {
+  let r = value % m
+  case r < 0 {
+    True -> r + m
+    False -> r
+  }
 }
 
 fn wifi_security_name(security: WifiSecurity) -> String {
@@ -265,7 +364,13 @@ fn percent_encode(value: String) -> String {
 }
 
 fn escape_vcard(value: String) -> String {
+  // Strip raw CR and NUL (RFC 2426 §2.4.2 forbids them in TEXT
+  // values), then escape the four reserved characters in spec
+  // order — backslash first so subsequent escapes are not
+  // double-escaped.
   value
+  |> string.replace(each: "\r", with: "")
+  |> string.replace(each: "\u{0000}", with: "")
   |> string.replace(each: "\\", with: "\\\\")
   |> string.replace(each: "\n", with: "\\n")
   |> string.replace(each: ",", with: "\\,")
@@ -273,19 +378,68 @@ fn escape_vcard(value: String) -> String {
 }
 
 fn escape_ical(value: String) -> String {
+  // Same TEXT-value rules as vCard (RFC 5545 §3.3.11): strip raw CR
+  // and NUL before escaping the reserved set.
   value
+  |> string.replace(each: "\r", with: "")
+  |> string.replace(each: "\u{0000}", with: "")
   |> string.replace(each: "\\", with: "\\\\")
   |> string.replace(each: "\n", with: "\\n")
   |> string.replace(each: ",", with: "\\,")
   |> string.replace(each: ";", with: "\\;")
 }
 
+/// Fold one logical content line per RFC 5545 §3.1 / RFC 2426 §2.6:
+/// a line longer than 75 octets is split into 75-octet runs joined
+/// by `CRLF<space>`. Folding is performed at grapheme boundaries
+/// rather than raw bytes so multi-byte UTF-8 sequences are never
+/// split. The single-line case is a fast path that returns the
+/// input unchanged.
+fn fold_line(line: String) -> String {
+  case string.byte_size(line) <= 75 {
+    True -> line
+    False -> fold_line_loop(string.to_graphemes(line), 0, [], [])
+  }
+}
+
+fn fold_line_loop(
+  graphemes: List(String),
+  current_bytes: Int,
+  current_acc: List(String),
+  folded_acc: List(String),
+) -> String {
+  case graphemes {
+    [] -> {
+      let last = string.concat(list.reverse(current_acc))
+      let parts = list.reverse([last, ..folded_acc])
+      string.join(parts, with: "\r\n ")
+    }
+    [head, ..tail] -> {
+      let head_bytes = string.byte_size(head)
+      case current_bytes + head_bytes > 75 {
+        True -> {
+          let chunk = string.concat(list.reverse(current_acc))
+          fold_line_loop(tail, head_bytes, [head], [chunk, ..folded_acc])
+        }
+        False ->
+          fold_line_loop(
+            tail,
+            current_bytes + head_bytes,
+            [head, ..current_acc],
+            folded_acc,
+          )
+      }
+    }
+  }
+}
+
 fn format_datetime(unix: Int, all_day: Bool) -> String {
   let #(year, month, day, hour, minute, second) = unix_to_utc(unix)
+  let year_clamped = clamp_year(year)
   case all_day {
-    True -> pad(year, 4) <> pad(month, 2) <> pad(day, 2)
+    True -> pad(year_clamped, 4) <> pad(month, 2) <> pad(day, 2)
     False ->
-      pad(year, 4)
+      pad(year_clamped, 4)
       <> pad(month, 2)
       <> pad(day, 2)
       <> "T"
@@ -296,9 +450,26 @@ fn format_datetime(unix: Int, all_day: Bool) -> String {
   }
 }
 
+fn clamp_year(year: Int) -> Int {
+  // RFC 5545 §3.3.5 fixes the year at 4 digits. Values outside
+  // `[1, 9999]` are clamped rather than emitted with a 5-digit
+  // year that breaks the fixed-width format (#10). Negative-input
+  // overflow (#9) is bounded by `floor_div` upstream so this
+  // mostly handles the Y10K side.
+  case year < 1, year > 9999 {
+    True, _ -> 1
+    _, True -> 9999
+    _, _ -> year
+  }
+}
+
 fn unix_to_utc(unix: Int) -> #(Int, Int, Int, Int, Int, Int) {
-  let days = unix / 86_400
-  let seconds_of_day = unix % 86_400
+  // Floor-divide so negative `unix` values produce non-negative
+  // sub-day components — Gleam's `/` and `%` truncate toward zero,
+  // which leaks negatives into the hour/minute/second components
+  // for any pre-epoch input (#9).
+  let days = floor_div(unix, 86_400)
+  let seconds_of_day = floor_mod(unix, 86_400)
   let #(year, month, day) = civil_from_days(days)
   let hour = seconds_of_day / 3600
   let minute = { seconds_of_day % 3600 } / 60
@@ -306,9 +477,26 @@ fn unix_to_utc(unix: Int) -> #(Int, Int, Int, Int, Int, Int) {
   #(year, month, day, hour, minute, second)
 }
 
+fn floor_div(a: Int, b: Int) -> Int {
+  let q = a / b
+  let r = a - q * b
+  case r != 0 && { r < 0 } != { b < 0 } {
+    True -> q - 1
+    False -> q
+  }
+}
+
+fn floor_mod(a: Int, b: Int) -> Int {
+  let r = a % b
+  case r != 0 && { r < 0 } != { b < 0 } {
+    True -> r + b
+    False -> r
+  }
+}
+
 fn civil_from_days(days: Int) -> #(Int, Int, Int) {
   let z = days + 719_468
-  let era = z / 146_097
+  let era = floor_div(z, 146_097)
   let doe = z - era * 146_097
   let yoe = { doe - doe / 1460 + doe / 36_524 - doe / 146_096 } / 365
   let y = yoe + era * 400

--- a/src/qrkit/content.gleam
+++ b/src/qrkit/content.gleam
@@ -158,6 +158,7 @@ pub fn vcard_to_string(card: VCard) -> String {
   |> present_lines([])
   |> list.map(fold_line)
   |> string.join(with: "\r\n")
+  |> append_crlf
 }
 
 /// Build a `mailto:` payload, percent-encoding every parameter
@@ -273,6 +274,15 @@ pub fn event_to_string(event: CalendarEvent) -> String {
   |> present_lines([])
   |> list.map(fold_line)
   |> string.join(with: "\r\n")
+  |> append_crlf
+}
+
+fn append_crlf(s: String) -> String {
+  // RFC 5545 §3.1 / RFC 2426 §2.1: every content line — including
+  // the final BEGIN/END boundary — is terminated by CRLF. Without
+  // this, the trailing END:VCALENDAR / END:VCARD line has no
+  // terminator and strict consumers reject the document.
+  s <> "\r\n"
 }
 
 fn adjust_end_for_all_day(start_unix: Int, end_unix: Int, all_day: Bool) -> Int {

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -122,25 +122,49 @@ pub fn mixed_content_falls_back_to_byte_mode_test() -> Nil {
 }
 
 pub fn vcard_content_helper_test() -> Nil {
+  // RFC 2426 §2.1: CRLF line terminator. The renderer also always
+  // emits N and FN (mandatory per §3.1.1 / §3.1.2).
   content.vcard()
   |> content.with_name("Nao")
   |> content.with_phone("+81-90-0000-0000")
   |> content.with_email("nao@example.com")
   |> content.vcard_to_string()
   |> should.equal(
-    "BEGIN:VCARD\nVERSION:3.0\nN:Nao\nFN:Nao\nTEL:+81-90-0000-0000\nEMAIL:nao@example.com\nEND:VCARD",
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\r\nFN:Nao\r\nTEL:+81-90-0000-0000\r\nEMAIL:nao@example.com\r\nEND:VCARD",
   )
 }
 
+// Issue #15: vcard_to_string always emits the RFC 2426 MANDATORY N
+// and FN properties even when the caller did not set a name.
+pub fn vcard_emits_required_n_and_fn_when_name_missing_test() -> Nil {
+  content.vcard()
+  |> content.vcard_to_string()
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:;;;;\r\nFN:\r\nEND:VCARD")
+}
+
 pub fn email_content_percent_encodes_reserved_chars_test() -> Nil {
+  // Issue #17: the `to` parameter is now percent-encoded too — the
+  // `@` becomes `%40`, but the renderer round-trips cleanly when
+  // the addr-spec contains reserved characters (`?`, `&`, `#`,
+  // space).
   content.email(
     to: "you@example.com",
     subject: "status & next?",
     body: "100% ready = yes\nship it",
   )
   |> should.equal(
-    "mailto:you@example.com?subject=status%20%26%20next%3F&body=100%25%20ready%20%3D%20yes%0Aship%20it",
+    "mailto:you%40example.com?subject=status%20%26%20next%3F&body=100%25%20ready%20%3D%20yes%0Aship%20it",
   )
+}
+
+// Issue #17: every URI-reserved character in `to` is now escaped.
+pub fn email_to_with_reserved_chars_is_escaped_test() -> Nil {
+  content.email(to: "a?b@c.com", subject: "S", body: "B")
+  |> should.equal("mailto:a%3Fb%40c.com?subject=S&body=B")
+  content.email(to: "a&b@c.com", subject: "S", body: "B")
+  |> should.equal("mailto:a%26b%40c.com?subject=S&body=B")
+  content.email(to: "a#b@c.com", subject: "S", body: "B")
+  |> should.equal("mailto:a%23b%40c.com?subject=S&body=B")
 }
 
 pub fn vcard_escapes_reserved_chars_test() -> Nil {
@@ -149,11 +173,29 @@ pub fn vcard_escapes_reserved_chars_test() -> Nil {
   |> content.with_address("Tokyo;JP,\nLine2")
   |> content.vcard_to_string()
   |> should.equal(
-    "BEGIN:VCARD\nVERSION:3.0\nN:Nao\\;Inc\\,\\nDev\nFN:Nao\\;Inc\\,\\nDev\nADR:Tokyo\\;JP\\,\\nLine2\nEND:VCARD",
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\\;Inc\\,\\nDev\r\nFN:Nao\\;Inc\\,\\nDev\r\nADR:Tokyo\\;JP\\,\\nLine2\r\nEND:VCARD",
   )
 }
 
+// Issue #11: escape helpers strip raw CR and NUL from TEXT values
+// (RFC 5545 §3.3.11 / RFC 2426 §2.4.2 forbid them; CR in particular
+// breaks line termination by emulating CRLF inside a value).
+pub fn vcard_escape_strips_raw_cr_and_nul_test() -> Nil {
+  content.vcard()
+  |> content.with_name("A\rB")
+  |> content.vcard_to_string()
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD")
+  content.vcard()
+  |> content.with_name("A\u{0000}B")
+  |> content.vcard_to_string()
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD")
+}
+
 pub fn calendar_event_escapes_text_fields_test() -> Nil {
+  // RFC 5545 §3.1: CRLF terminator. §3.7.3 + §3.6.1: PRODID, UID,
+  // DTSTAMP are required (#14). UID is a deterministic synthesis of
+  // (title-hash, start, end); DTSTAMP defaults to start_unix
+  // (no clock is available in a pure renderer).
   content.event(
     title: "Sync;One,Two",
     start_unix: 1_778_752_800,
@@ -163,8 +205,69 @@ pub fn calendar_event_escapes_text_fields_test() -> Nil {
   |> content.with_description("Line1\nLine2;done,ok")
   |> content.event_to_string()
   |> should.equal(
-    "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Sync\\;One\\,Two\nDTSTART:20260514T100000Z\nDTEND:20260514T110000Z\nLOCATION:Room\\;A\\,\\nTokyo\nDESCRIPTION:Line1\\nLine2\\;done\\,ok\nEND:VEVENT\nEND:VCALENDAR",
+    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:1868597102-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\\;One\\,Two\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Room\\;A\\,\\nTokyo\r\nDESCRIPTION:Line1\\nLine2\\;done\\,ok\r\nEND:VEVENT\r\nEND:VCALENDAR",
   )
+}
+
+// Issue #14: event_to_string emits PRODID + UID + DTSTAMP.
+pub fn calendar_event_includes_required_properties_test() -> Nil {
+  let s =
+    content.event(title: "X", start_unix: 0, end_unix: 0)
+    |> content.event_to_string
+  s
+  |> string.contains("PRODID:")
+  |> should.be_true
+  s
+  |> string.contains("UID:")
+  |> should.be_true
+  s
+  |> string.contains("DTSTAMP:")
+  |> should.be_true
+}
+
+// Issue #16: in all_day mode, DTEND is bumped to start + 1 day when
+// the caller passed end == start. RFC 5545 §3.6.1 mandates a
+// non-inclusive end for DATE-valued events.
+pub fn calendar_event_all_day_dtend_non_inclusive_test() -> Nil {
+  let s =
+    content.event(title: "x", start_unix: 0, end_unix: 0)
+    |> content.with_all_day(True)
+    |> content.event_to_string
+  s
+  |> string.contains("DTSTART;VALUE=DATE:19700101")
+  |> should.be_true
+  s
+  |> string.contains("DTEND;VALUE=DATE:19700102")
+  |> should.be_true
+}
+
+// Issue #9: negative unix is floor-divided so sub-day components do
+// not go negative.
+pub fn calendar_event_negative_unix_formats_correctly_test() -> Nil {
+  let s =
+    content.event(title: "x", start_unix: -1, end_unix: -1)
+    |> content.event_to_string
+  // -1 second past epoch = 1969-12-31 23:59:59 UTC.
+  s
+  |> string.contains("DTSTART:19691231T235959Z")
+  |> should.be_true
+}
+
+// Issue #10: years beyond Y10K are clamped to 9999 to keep the
+// RFC 5545 fixed-width YYYYMMDDTHHMMSSZ format. Pre-Y1 years are
+// clamped to 1.
+pub fn calendar_event_year_clamps_to_4_digit_range_test() -> Nil {
+  // 253_402_300_800 unix = Jan 1, 10000 UTC -> clamped to year 9999.
+  let s_y10k =
+    content.event(
+      title: "x",
+      start_unix: 253_402_300_800,
+      end_unix: 253_402_300_800,
+    )
+    |> content.event_to_string
+  s_y10k
+  |> string.contains("DTSTART:9999")
+  |> should.be_true
 }
 
 pub fn ascii_renderer_test() -> Nil {

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -130,7 +130,7 @@ pub fn vcard_content_helper_test() -> Nil {
   |> content.with_email("nao@example.com")
   |> content.vcard_to_string()
   |> should.equal(
-    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\r\nFN:Nao\r\nTEL:+81-90-0000-0000\r\nEMAIL:nao@example.com\r\nEND:VCARD",
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\r\nFN:Nao\r\nTEL:+81-90-0000-0000\r\nEMAIL:nao@example.com\r\nEND:VCARD\r\n",
   )
 }
 
@@ -139,7 +139,7 @@ pub fn vcard_content_helper_test() -> Nil {
 pub fn vcard_emits_required_n_and_fn_when_name_missing_test() -> Nil {
   content.vcard()
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:;;;;\r\nFN:\r\nEND:VCARD")
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:;;;;\r\nFN:\r\nEND:VCARD\r\n")
 }
 
 pub fn email_content_percent_encodes_reserved_chars_test() -> Nil {
@@ -173,7 +173,7 @@ pub fn vcard_escapes_reserved_chars_test() -> Nil {
   |> content.with_address("Tokyo;JP,\nLine2")
   |> content.vcard_to_string()
   |> should.equal(
-    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\\;Inc\\,\\nDev\r\nFN:Nao\\;Inc\\,\\nDev\r\nADR:Tokyo\\;JP\\,\\nLine2\r\nEND:VCARD",
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Nao\\;Inc\\,\\nDev\r\nFN:Nao\\;Inc\\,\\nDev\r\nADR:Tokyo\\;JP\\,\\nLine2\r\nEND:VCARD\r\n",
   )
 }
 
@@ -184,11 +184,11 @@ pub fn vcard_escape_strips_raw_cr_and_nul_test() -> Nil {
   content.vcard()
   |> content.with_name("A\rB")
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD")
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n")
   content.vcard()
   |> content.with_name("A\u{0000}B")
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD")
+  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n")
 }
 
 pub fn calendar_event_escapes_text_fields_test() -> Nil {
@@ -205,7 +205,7 @@ pub fn calendar_event_escapes_text_fields_test() -> Nil {
   |> content.with_description("Line1\nLine2;done,ok")
   |> content.event_to_string()
   |> should.equal(
-    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:1868597102-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\\;One\\,Two\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Room\\;A\\,\\nTokyo\r\nDESCRIPTION:Line1\\nLine2\\;done\\,ok\r\nEND:VEVENT\r\nEND:VCALENDAR",
+    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:1868597102-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\\;One\\,Two\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Room\\;A\\,\\nTokyo\r\nDESCRIPTION:Line1\\nLine2\\;done\\,ok\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
   )
 }
 
@@ -267,6 +267,19 @@ pub fn calendar_event_year_clamps_to_4_digit_range_test() -> Nil {
     |> content.event_to_string
   s_y10k
   |> string.contains("DTSTART:9999")
+  |> should.be_true
+  // -62_167_219_200 unix is roughly Jan 1, 0000 UTC — earlier than
+  // year 1, so the renderer clamps to year 0001 rather than emitting
+  // a 0-prefixed year that breaks the RFC 5545 fixed-width format.
+  let s_pre_y1 =
+    content.event(
+      title: "x",
+      start_unix: -62_167_219_200,
+      end_unix: -62_167_219_200,
+    )
+    |> content.event_to_string
+  s_pre_y1
+  |> string.contains("DTSTART:0001")
   |> should.be_true
 }
 

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -139,7 +139,9 @@ pub fn vcard_content_helper_test() -> Nil {
 pub fn vcard_emits_required_n_and_fn_when_name_missing_test() -> Nil {
   content.vcard()
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:;;;;\r\nFN:\r\nEND:VCARD\r\n")
+  |> should.equal(
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:;;;;\r\nFN:\r\nEND:VCARD\r\n",
+  )
 }
 
 pub fn email_content_percent_encodes_reserved_chars_test() -> Nil {
@@ -184,11 +186,15 @@ pub fn vcard_escape_strips_raw_cr_and_nul_test() -> Nil {
   content.vcard()
   |> content.with_name("A\rB")
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n")
+  |> should.equal(
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n",
+  )
   content.vcard()
   |> content.with_name("A\u{0000}B")
   |> content.vcard_to_string()
-  |> should.equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n")
+  |> should.equal(
+    "BEGIN:VCARD\r\nVERSION:3.0\r\nN:AB\r\nFN:AB\r\nEND:VCARD\r\n",
+  )
 }
 
 pub fn calendar_event_escapes_text_fields_test() -> Nil {

--- a/test/readme_examples_test.gleam
+++ b/test/readme_examples_test.gleam
@@ -212,6 +212,11 @@ pub fn readme_content_helpers_test() -> Nil {
 // ---------------------------------------------------------------------------
 
 fn readme_meeting_qr() -> Result(qrkit.QrCode, qrkit.EncodeError) {
+  // The RFC-required PRODID / UID / DTSTAMP properties added in
+  // qrkit content #14 grow the payload past what default-ECC
+  // encoding leaves room for at small versions, so the README
+  // example now constructs the builder with a Low ECC for the
+  // illustrative encode.
   content.event(
     title: "Sync",
     start_unix: 1_778_752_800,
@@ -220,7 +225,9 @@ fn readme_meeting_qr() -> Result(qrkit.QrCode, qrkit.EncodeError) {
   |> content.with_location("Online")
   |> content.with_description("Project sync meeting")
   |> content.event_to_string
-  |> qrkit.encode
+  |> qrkit.new
+  |> qrkit.with_ecc(types.Low)
+  |> qrkit.build
 }
 
 pub fn readme_meeting_qr_test() -> Nil {
@@ -229,6 +236,8 @@ pub fn readme_meeting_qr_test() -> Nil {
 }
 
 pub fn readme_meeting_qr_payload_matches_documented_times_test() -> Nil {
+  // Payload now CRLF-terminated and carries the RFC-required
+  // PRODID / UID / DTSTAMP properties (qrkit content #12, #14).
   content.event(
     title: "Sync",
     start_unix: 1_778_752_800,
@@ -238,7 +247,7 @@ pub fn readme_meeting_qr_payload_matches_documented_times_test() -> Nil {
   |> content.with_description("Project sync meeting")
   |> content.event_to_string
   |> should.equal(
-    "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:Sync\nDTSTART:20260514T100000Z\nDTEND:20260514T110000Z\nLOCATION:Online\nDESCRIPTION:Project sync meeting\nEND:VEVENT\nEND:VCALENDAR",
+    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:2592443-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Online\r\nDESCRIPTION:Project sync meeting\r\nEND:VEVENT\r\nEND:VCALENDAR",
   )
 }
 

--- a/test/readme_examples_test.gleam
+++ b/test/readme_examples_test.gleam
@@ -247,7 +247,7 @@ pub fn readme_meeting_qr_payload_matches_documented_times_test() -> Nil {
   |> content.with_description("Project sync meeting")
   |> content.event_to_string
   |> should.equal(
-    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:2592443-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Online\r\nDESCRIPTION:Project sync meeting\r\nEND:VEVENT\r\nEND:VCALENDAR",
+    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//nao1215//qrkit//EN\r\nBEGIN:VEVENT\r\nUID:2592443-1778752800-1778756400@qrkit.nao1215\r\nDTSTAMP:20260514T100000Z\r\nSUMMARY:Sync\r\nDTSTART:20260514T100000Z\r\nDTEND:20260514T110000Z\r\nLOCATION:Online\r\nDESCRIPTION:Project sync meeting\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
   )
 }
 


### PR DESCRIPTION
## Summary

`qrkit/content`'s `event_to_string` and `vcard_to_string` produced output that mostly worked with lenient consumers but was rejected by strict parsers — and silently broke at a few documented spec corners (negative `unix`, Y10K years, raw CR in TEXT values, identical-day all-day events, etc.). This PR collapses the nine open issues filed against the module (#9–#17) into a single compliance pass against RFC 5545 (iCalendar) and RFC 2426 (vCard 3.0).

## Changes

- [src/qrkit/content.gleam](src/qrkit/content.gleam) `event_to_string` and `vcard_to_string` now terminate lines with `CRLF` (`\r\n`) per RFC 5545 §3.1 / RFC 2426 §2.1, not LF-only (#12).
- [src/qrkit/content.gleam](src/qrkit/content.gleam) Both renderers fold content lines longer than 75 octets with `CRLF<space>` continuation per RFC 5545 §3.1 / RFC 2426 §2.6 (#13). Folding is grapheme-aware (`string.byte_size` per grapheme), so multi-byte UTF-8 sequences are never split mid-character.
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `escape_ical` / `escape_vcard` strip raw `\r` and NUL before escaping the reserved set (RFC 5545 §3.3.11 / RFC 2426 §2.4.2 forbid them in TEXT values; raw CR in particular emulated CRLF and terminated the line prematurely) (#11).
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `event_to_string` emits the RFC-required `PRODID:-//nao1215//qrkit//EN` (VCALENDAR-level), plus `UID` and `DTSTAMP` (VEVENT-level) (#14). `UID` is a deterministic synthesis of `<title-hash>-<start>-<end>@qrkit.nao1215` (a Java-style rolling 31x hash with explicit modulo per step so intermediate values stay below JavaScript's 2^53 safe-integer ceiling and match on both Erlang and JavaScript targets). `DTSTAMP` defaults to the event's `start_unix` — no clock is available in a pure rendering function and the iCal object must carry *some* DTSTAMP value.
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `vcard_to_string` always emits the RFC 2426 MANDATORY `N` and `FN` properties (§3.1.1 / §3.1.2). When the caller did not call `with_name`, both are emitted with empty values (`N:;;;;` and `FN:`) so the structure stays spec-conformant (#15).
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `event_to_string` in `all_day` mode bumps `DTEND` to `start + 1 day` when the caller passed `end_unix == start_unix`, matching RFC 5545 §3.6.1's non-inclusive-end requirement for DATE-valued events (#16). The transformation is local to `event_to_string` so callers' stored `CalendarEvent` value is unchanged.
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `event_to_string` handles pre-epoch unix values by floor-dividing into days / seconds-of-day (Gleam's `/` and `%` truncate toward zero, which had let negative sub-day components leak into the formatted output) (#9).
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `event_to_string` clamps year to `[1, 9999]` so values beyond Y10K (or before Y1) cannot break the RFC 5545 fixed-width `YYYYMMDDTHHMMSSZ` format (#10). The clamp is the conservative choice — a Result-returning signature would break callers using `Int` timestamps that happen to drift past the cap.
- [src/qrkit/content.gleam](src/qrkit/content.gleam) `email` percent-encodes the `to` addr-spec along with `subject` and `body`, so reserved characters (`?`, `&`, `#`, space) in `to` no longer produce a malformed `mailto:` URI (#17).
- [test/qrkit_test.gleam](test/qrkit_test.gleam) Existing tests updated to assert the new CRLF / PRODID / UID / DTSTAMP shape, plus new regression tests pinning the behaviour of each fix above.
- [test/readme_examples_test.gleam](test/readme_examples_test.gleam) The README meeting-QR example now constructs the encoder via the builder (`qrkit.new |> qrkit.with_ecc(Low) |> qrkit.build`) because the RFC-required PRODID / UID / DTSTAMP grow the payload past the default-ECC capacity for the documented example. Payload-equality test updated for the new CRLF / required-properties shape.
- [CHANGELOG.md](CHANGELOG.md) Unreleased Fixed entry listing all nine issues and the specific RFC references.

## Design Decisions

The fixes are bundled into one PR rather than split per-issue because every fix touches the same module (often the same function) and several of them stack: line folding is meaningless without CRLF, the escape helpers reading raw CR need the CRLF fix to actually matter for line termination, the required `UID` is what made the `all_day` non-inclusive end testable from a strict consumer, and the year clamp interacts with the floor-division fix. Splitting would have produced several PRs each blocked on review of the previous merge.

Issue #8 (ascii renderer `with_margin`) is intentionally out of scope here — it's a different module (`qrkit/render/ascii`) and a feature add rather than a bug fix; it can land in a follow-up PR cleanly.

Closes #9, closes #10, closes #11, closes #12, closes #13, closes #14, closes #15, closes #16, closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar and contact QR code generation to meet RFC standards.
  * Fixed line formatting and special character handling in calendar and contact data.
  * Corrected email address encoding to prevent malformed mailto links.
  * Fixed all-day event date boundaries to match RFC specifications.
  * Enhanced reliability for edge cases with historical timestamps and year values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/qrkit/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->