### PR TITLE
feat(render/ascii): expose AsciiOptions with with_margin builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `qrkit/render/ascii`: `AsciiOptions` opaque type plus `default_options/0`, `with_margin/2`, `with_inverse_option/2`, `to_string_with/2`, and `to_string_compact_with/2` — mirroring the builder-style options shape `qrkit/render/svg` already exposes (`svg.default_options |> svg.with_margin(2)`). The new functions let terminal callers tighten the quiet zone for debug dumps, fixture diffs, and inline-doc panels without giving up the ISO/IEC 18004 4-module default for camera-scannable output. Existing `to_string/1`, `with_inverse/1`, and `to_string_compact/1` keep the 4-module default and are unchanged at the API level. (#8)
+
 ## [0.1.0] - 2026-05-14
 
 ### Changed

--- a/src/qrkit/render/ascii.gleam
+++ b/src/qrkit/render/ascii.gleam
@@ -1,52 +1,134 @@
 //// Terminal renderers for qrkit QR codes.
+////
+//// Default callers use [`to_string`](#to_string),
+//// [`with_inverse`](#with_inverse), and
+//// [`to_string_compact`](#to_string_compact) which keep the
+//// ISO/IEC 18004 4-module quiet zone. Callers that need a tighter
+//// margin (debug dumps, fixture diffs, README terminal panels)
+//// build an [`AsciiOptions`](#AsciiOptions) via
+//// [`default_options`](#default_options) /
+//// [`with_margin`](#with_margin) / [`with_inverse_option`](#with_inverse_option)
+//// and render through [`to_string_with`](#to_string_with) or
+//// [`to_string_compact_with`](#to_string_compact_with).
 
 import gleam/list
 import gleam/string
 import qrkit
 
-const quiet_zone = 4
+const default_quiet_zone = 4
 
-/// Render the QR code using double-width full blocks.
+/// Render options for the terminal renderers. Build with
+/// [`default_options`](#default_options) and the `with_*` setters.
+/// `pub opaque` so the renderer can grow knobs (background colour,
+/// glyph set, ...) without breaking callers.
+pub opaque type AsciiOptions {
+  AsciiOptions(margin: Int, inverse: Bool)
+}
+
+/// Default rendering options: 4-module quiet zone (ISO/IEC 18004),
+/// non-inverted colours.
+pub fn default_options() -> AsciiOptions {
+  AsciiOptions(margin: default_quiet_zone, inverse: False)
+}
+
+/// Override the quiet zone in modules. Values below 0 are clamped
+/// to 0. The 4-module default is the ISO/IEC 18004 minimum for
+/// reliable scannability — tightening it is appropriate for
+/// debug / fixture / inline-doc output, not for QR codes intended
+/// to be scanned from a camera.
+pub fn with_margin(options: AsciiOptions, modules: Int) -> AsciiOptions {
+  let AsciiOptions(_, inverse) = options
+  let clamped = case modules < 0 {
+    True -> 0
+    False -> modules
+  }
+  AsciiOptions(margin: clamped, inverse: inverse)
+}
+
+/// Toggle inverted rendering (dark cells render as spaces, light
+/// cells as blocks).
+pub fn with_inverse_option(options: AsciiOptions, inverse: Bool) -> AsciiOptions {
+  let AsciiOptions(margin, _) = options
+  AsciiOptions(margin: margin, inverse: inverse)
+}
+
+/// Render the QR code using double-width full blocks. Uses the
+/// ISO/IEC 18004 default 4-module quiet zone. See
+/// [`to_string_with`](#to_string_with) when a different margin is
+/// needed.
 pub fn to_string(qr: qrkit.QrCode) -> String {
-  render(qr, dark: "██", light: "  ")
+  render(qr, dark: "██", light: "  ", margin: default_quiet_zone)
 }
 
-/// Render the QR code with inverted colours.
+/// Render the QR code with inverted colours and the default
+/// 4-module quiet zone.
 pub fn with_inverse(qr: qrkit.QrCode) -> String {
-  render(qr, dark: "  ", light: "██")
+  render(qr, dark: "  ", light: "██", margin: default_quiet_zone)
 }
 
-/// Render the QR code using Unicode half blocks to halve the height.
+/// Render using double-width full blocks with caller-supplied
+/// [`AsciiOptions`](#AsciiOptions). The `inverse` setting on the
+/// options flips dark / light glyphs identically to
+/// [`with_inverse`](#with_inverse).
+pub fn to_string_with(qr: qrkit.QrCode, options: AsciiOptions) -> String {
+  let AsciiOptions(margin, inverse) = options
+  case inverse {
+    True -> render(qr, dark: "  ", light: "██", margin: margin)
+    False -> render(qr, dark: "██", light: "  ", margin: margin)
+  }
+}
+
+/// Render the QR code using Unicode half blocks to halve the height,
+/// keeping the default 4-module quiet zone. See
+/// [`to_string_compact_with`](#to_string_compact_with) for a
+/// caller-controlled margin.
 pub fn to_string_compact(qr: qrkit.QrCode) -> String {
-  let padded = pad_rows(qrkit.rows(qr))
+  let padded = pad_rows(qrkit.rows(qr), default_quiet_zone)
   compact_lines(padded, [])
   |> string.join(with: "\n")
 }
 
-fn render(qr: qrkit.QrCode, dark dark: String, light light: String) -> String {
-  let rows = pad_rows(qrkit.rows(qr))
+/// Render the QR code using Unicode half blocks with a caller-
+/// supplied margin. The `inverse` setting on
+/// [`AsciiOptions`](#AsciiOptions) is currently ignored for the
+/// half-block renderer — the compact form's glyph set already
+/// encodes both top and bottom modules per character cell.
+pub fn to_string_compact_with(qr: qrkit.QrCode, options: AsciiOptions) -> String {
+  let AsciiOptions(margin, _inverse) = options
+  let padded = pad_rows(qrkit.rows(qr), margin)
+  compact_lines(padded, [])
+  |> string.join(with: "\n")
+}
+
+fn render(
+  qr: qrkit.QrCode,
+  dark dark: String,
+  light light: String,
+  margin margin: Int,
+) -> String {
+  let rows = pad_rows(qrkit.rows(qr), margin)
   rows
   |> list.map(fn(row) { render_row(row, dark, light) })
   |> string.join(with: "\n")
 }
 
-fn pad_rows(rows: List(List(Bool))) -> List(List(Bool)) {
+fn pad_rows(rows: List(List(Bool)), margin: Int) -> List(List(Bool)) {
   let width = case rows {
     [first, ..] -> list.length(first)
     [] -> 0
   }
-  let padded_row = list.repeat(False, width + quiet_zone * 2)
+  let padded_row = list.repeat(False, width + margin * 2)
   let body =
     rows
     |> list.map(fn(row) {
       list.append(
-        list.repeat(False, quiet_zone),
-        list.append(row, list.repeat(False, quiet_zone)),
+        list.repeat(False, margin),
+        list.append(row, list.repeat(False, margin)),
       )
     })
   list.append(
-    list.repeat(padded_row, quiet_zone),
-    list.append(body, list.repeat(padded_row, quiet_zone)),
+    list.repeat(padded_row, margin),
+    list.append(body, list.repeat(padded_row, margin)),
   )
 }
 

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -174,6 +174,58 @@ pub fn ascii_renderer_test() -> Nil {
   |> should.be_false
 }
 
+// Issue #8: ascii renderer exposes a builder-style options object
+// for non-spec-mandated rendering (smaller margin in debug dumps,
+// fixture diffs, README terminal panels). The default 4-module
+// quiet zone matches ISO/IEC 18004 and the existing to_string output.
+pub fn ascii_with_margin_zero_strips_quiet_zone_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let tight =
+    ascii.default_options()
+    |> ascii.with_margin(0)
+    |> ascii.to_string_with(qr, _)
+  // With no quiet zone every line starts with a dark cell (the
+  // finder pattern's top-left corner) — the default output has a
+  // 4-module margin of light cells in front.
+  string.starts_with(tight, "██")
+  |> should.be_true
+}
+
+pub fn ascii_with_margin_matches_default_at_4_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let default = ascii.to_string(qr)
+  let rebuilt =
+    ascii.default_options()
+    |> ascii.with_margin(4)
+    |> ascii.to_string_with(qr, _)
+  default
+  |> should.equal(rebuilt)
+}
+
+pub fn ascii_with_inverse_option_flips_glyphs_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let inverted_via_options =
+    ascii.default_options()
+    |> ascii.with_inverse_option(True)
+    |> ascii.to_string_with(qr, _)
+  inverted_via_options
+  |> should.equal(ascii.with_inverse(qr))
+}
+
+pub fn ascii_with_margin_negative_clamps_to_zero_test() -> Nil {
+  let assert Ok(qr) = qrkit.encode("HELLO WORLD")
+  let zeroed =
+    ascii.default_options()
+    |> ascii.with_margin(0)
+    |> ascii.to_string_with(qr, _)
+  let negative =
+    ascii.default_options()
+    |> ascii.with_margin(-1)
+    |> ascii.to_string_with(qr, _)
+  zeroed
+  |> should.equal(negative)
+}
+
 pub fn svg_renderer_test() -> Nil {
   let assert Ok(qr) = qrkit.encode("HELLO WORLD")
   let xml = svg.to_string(qr, svg.default_options())


### PR DESCRIPTION
## Summary

`qrkit/render/svg` exposes a builder-style options object (`svg.default_options() |> svg.with_margin(2) |> svg.with_dark_color(...)`), but the parallel `qrkit/render/ascii` module hardcoded the 4-module quiet zone with no equivalent knob. Terminal callers (debug dumps, fixture diffs, README terminal panels) had no way to tighten the margin even when the output was not intended to be scanned from a camera. This PR adds a parallel `AsciiOptions` opaque type with `with_margin` and `with_inverse_option` setters, plus `to_string_with` / `to_string_compact_with` renderers that consume them.

## Changes

- [src/qrkit/render/ascii.gleam](src/qrkit/render/ascii.gleam) New `pub opaque type AsciiOptions` carrying `margin` (Int, default 4) and `inverse` (Bool, default False). Constructed via `default_options/0`, mutated via `with_margin/2` (negative values clamped to 0) and `with_inverse_option/2`.
- [src/qrkit/render/ascii.gleam](src/qrkit/render/ascii.gleam) New `to_string_with/2` and `to_string_compact_with/2` renderers that take an `AsciiOptions`. The existing `to_string/1`, `with_inverse/1`, and `to_string_compact/1` are unchanged at the API level — they keep the 4-module default that ISO/IEC 18004 mandates for camera-scannable QR codes.
- [test/qrkit_test.gleam](test/qrkit_test.gleam) Four new tests pinning the new behaviour: `margin: 0` strips the quiet zone (output starts with the finder-pattern dark cell), `margin: 4` matches the existing `to_string` output byte-for-byte, `with_inverse_option(True)` matches `with_inverse/1`, and negative margins are clamped to 0.
- [CHANGELOG.md](CHANGELOG.md) Unreleased Added entry.

## Design Decisions

I picked `to_string_with` / `to_string_compact_with` rather than overloading the existing `to_string` because Gleam has no default-argument syntax, and the trade-off the SVG renderer made — keep `default_options()` for the conservative shape, expose a typed `Options` for the opted-in shape — is the convention already growing in this codebase. The `pub opaque type` lets the renderer grow knobs (background colour, glyph set, alternate compact glyphs) without breaking callers.

`with_inverse_option` is intentionally distinct from the existing `with_inverse/1` (which takes a `QrCode`, not a partial options). Both names co-exist because `with_inverse(qr)` is the convenient one-call form for the inverse-without-margin-change case, and re-using the name for the setter would have produced a confusing two-arity-but-different-semantics surface.

Closes #8