### PR TITLE
fix(content): keep addr-spec @ literal in mailto to field per RFC 6068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- `qrkit/content.email` now keeps the addr-spec `@` separator (and the RFC 6068 §2 `some-delims` set: `!`, `$`, `'`, `(`, `)`, `*`, `+`, `;`, `:`, `,`) literal in the `to` field instead of percent-encoding everything via `uri.percent_encode`. The `to` field gets a narrower encoder that only escapes characters that would actually break URI parsing in this position (space, `?`, `&`, `#`, `<`, `>`, control bytes, non-ASCII); `subject` / `body` keep the wider RFC 3986 encoding. The previous behaviour produced `mailto:user%40example.com?...`, breaking canonical-form matching in some Android QR-handler whitelists. (#21)
+
 ## [0.2.0] - 2026-05-18
 
 ### Added

--- a/src/qrkit/content.gleam
+++ b/src/qrkit/content.gleam
@@ -161,15 +161,24 @@ pub fn vcard_to_string(card: VCard) -> String {
   |> append_crlf
 }
 
-/// Build a `mailto:` payload, percent-encoding every parameter
-/// including the `to` addr-spec.
+/// Build a `mailto:` payload conformant to RFC 6068.
+///
+/// The `to` field is encoded as an `addr-spec` (RFC 6068 §2): the
+/// structural separators `@` and `,` are kept literal, as are the
+/// `some-delims` characters (`!`, `$`, `'`, `(`, `)`, `*`, `+`,
+/// `;`, `:`) — only characters that would actually break URI parsing
+/// in this position (space, `?`, `&`, `#`, `<`, `>`, control bytes,
+/// non-ASCII) are percent-encoded. The `subject` and `body` hfvalues
+/// keep the wider RFC 3986 percent-encoding the stdlib provides so
+/// `?` / `&` / `#` / space / `%` are still escaped in those fields.
+/// (#21)
 pub fn email(
   to to: String,
   subject subject: String,
   body body: String,
 ) -> String {
   "mailto:"
-  <> percent_encode(to)
+  <> encode_addr_spec(to)
   <> "?subject="
   <> percent_encode(subject)
   <> "&body="
@@ -371,6 +380,128 @@ fn present_lines(lines: List(Option(String)), acc: List(String)) -> List(String)
 
 fn percent_encode(value: String) -> String {
   uri.percent_encode(value)
+}
+
+fn encode_addr_spec(value: String) -> String {
+  // RFC 6068 §2 addr-spec encoder for the `to` field of a `mailto:`
+  // URI. The `@` separator between local-part and domain, the `,`
+  // separator between addr-specs, and the `some-delims` set
+  // (`!` / `$` / `'` / `(` / `)` / `*` / `+` / `;` / `:`) are kept
+  // literal; only characters that would actually break URI parsing
+  // in this position — space, `?`, `&`, `#`, `<`, `>`, control bytes,
+  // and any non-ASCII codepoint — are percent-encoded. Encoding goes
+  // codepoint-by-codepoint so the same output is produced on both the
+  // Erlang and JavaScript targets, and so multi-byte UTF-8 sequences
+  // are expanded to one `%XX` per UTF-8 byte (RFC 3986 §2.5).
+  value
+  |> string.to_utf_codepoints
+  |> list.map(encode_addr_spec_codepoint)
+  |> string.concat
+}
+
+fn encode_addr_spec_codepoint(codepoint: UtfCodepoint) -> String {
+  let cp = string.utf_codepoint_to_int(codepoint)
+  case cp < 128 && is_addr_spec_literal_ascii(cp) {
+    True -> codepoint_to_string(codepoint)
+    False -> percent_encode_codepoint_utf8(cp)
+  }
+}
+
+fn codepoint_to_string(codepoint: UtfCodepoint) -> String {
+  string.from_utf_codepoints([codepoint])
+}
+
+fn is_addr_spec_literal_ascii(cp: Int) -> Bool {
+  // ALPHA / DIGIT / unreserved (`-` `.` `_` `~`) plus the structural
+  // separators of RFC 6068 §2 addr-spec list (`@`, `,`) and the
+  // some-delims set (`!`, `$`, `'`, `(`, `)`, `*`, `+`, `;`, `:`)
+  // stay literal. Everything else — including space, `?`, `&`, `#`,
+  // `<`, `>`, `"`, `[`, `]`, `\`, `/`, `=`, and any control byte —
+  // is percent-encoded.
+  is_alpha(cp)
+  || is_digit(cp)
+  || is_unreserved_punct(cp)
+  || is_addr_spec_separator(cp)
+  || is_some_delim(cp)
+}
+
+fn is_alpha(cp: Int) -> Bool {
+  { cp >= 0x41 && cp <= 0x5A } || { cp >= 0x61 && cp <= 0x7A }
+}
+
+fn is_digit(cp: Int) -> Bool {
+  cp >= 0x30 && cp <= 0x39
+}
+
+fn is_unreserved_punct(cp: Int) -> Bool {
+  // RFC 3986 §2.3 unreserved punctuation: `-` `.` `_` `~`.
+  cp == 0x2D || cp == 0x2E || cp == 0x5F || cp == 0x7E
+}
+
+fn is_addr_spec_separator(cp: Int) -> Bool {
+  // RFC 6068 §2: `@` separates local-part from domain, `,` separates
+  // addr-specs in a list.
+  cp == 0x40 || cp == 0x2C
+}
+
+fn is_some_delim(cp: Int) -> Bool {
+  // RFC 6068 §2 some-delims = "!" / "$" / "'" / "(" / ")" / "*" /
+  // "+" / ";" / ":". (`,` and `@` are handled by
+  // `is_addr_spec_separator` above so this set is the rest.)
+  cp == 0x21
+  || cp == 0x24
+  || cp == 0x27
+  || cp == 0x28
+  || cp == 0x29
+  || cp == 0x2A
+  || cp == 0x2B
+  || cp == 0x3B
+  || cp == 0x3A
+}
+
+fn percent_encode_codepoint_utf8(cp: Int) -> String {
+  // Expand the codepoint to its UTF-8 bytes (RFC 3629) and emit
+  // `%XX` for each. ASCII (`cp < 0x80`) falls through the 1-byte
+  // branch so the same routine handles both ASCII characters that
+  // need escaping (e.g. space → `%20`) and non-ASCII codepoints.
+  case cp < 0x80, cp < 0x800, cp < 0x10000 {
+    True, _, _ -> to_hex_byte(cp)
+    _, True, _ -> to_hex_byte(0xC0 + cp / 64) <> to_hex_byte(0x80 + cp % 64)
+    _, _, True ->
+      to_hex_byte(0xE0 + cp / 4096)
+      <> to_hex_byte(0x80 + cp / 64 % 64)
+      <> to_hex_byte(0x80 + cp % 64)
+    _, _, _ ->
+      to_hex_byte(0xF0 + cp / 262_144)
+      <> to_hex_byte(0x80 + cp / 4096 % 64)
+      <> to_hex_byte(0x80 + cp / 64 % 64)
+      <> to_hex_byte(0x80 + cp % 64)
+  }
+}
+
+fn to_hex_byte(byte: Int) -> String {
+  "%" <> hex_digit(byte / 16) <> hex_digit(byte % 16)
+}
+
+fn hex_digit(nibble: Int) -> String {
+  case nibble {
+    0 -> "0"
+    1 -> "1"
+    2 -> "2"
+    3 -> "3"
+    4 -> "4"
+    5 -> "5"
+    6 -> "6"
+    7 -> "7"
+    8 -> "8"
+    9 -> "9"
+    10 -> "A"
+    11 -> "B"
+    12 -> "C"
+    13 -> "D"
+    14 -> "E"
+    _ -> "F"
+  }
 }
 
 fn escape_vcard(value: String) -> String {

--- a/test/qrkit_test.gleam
+++ b/test/qrkit_test.gleam
@@ -145,28 +145,72 @@ pub fn vcard_emits_required_n_and_fn_when_name_missing_test() -> Nil {
 }
 
 pub fn email_content_percent_encodes_reserved_chars_test() -> Nil {
-  // Issue #17: the `to` parameter is now percent-encoded too — the
-  // `@` becomes `%40`, but the renderer round-trips cleanly when
-  // the addr-spec contains reserved characters (`?`, `&`, `#`,
-  // space).
+  // Issue #21: the `to` addr-spec keeps `@` literal per RFC 6068 §2.
+  // Subject / body keep the wider RFC 3986 percent-encoding the
+  // stdlib provides so `?` / `&` / `#` / space / `%` are still
+  // escaped in those hfvalues.
   content.email(
     to: "you@example.com",
     subject: "status & next?",
     body: "100% ready = yes\nship it",
   )
   |> should.equal(
-    "mailto:you%40example.com?subject=status%20%26%20next%3F&body=100%25%20ready%20%3D%20yes%0Aship%20it",
+    "mailto:you@example.com?subject=status%20%26%20next%3F&body=100%25%20ready%20%3D%20yes%0Aship%20it",
   )
 }
 
-// Issue #17: every URI-reserved character in `to` is now escaped.
+// Issue #21: URI-structural characters that would actually break
+// parsing in the addr-spec position (`?`, `&`, `#`) are still
+// encoded; `@` is kept literal because it is the addr-spec
+// separator per RFC 6068 §2.
 pub fn email_to_with_reserved_chars_is_escaped_test() -> Nil {
   content.email(to: "a?b@c.com", subject: "S", body: "B")
-  |> should.equal("mailto:a%3Fb%40c.com?subject=S&body=B")
+  |> should.equal("mailto:a%3Fb@c.com?subject=S&body=B")
   content.email(to: "a&b@c.com", subject: "S", body: "B")
-  |> should.equal("mailto:a%26b%40c.com?subject=S&body=B")
+  |> should.equal("mailto:a%26b@c.com?subject=S&body=B")
   content.email(to: "a#b@c.com", subject: "S", body: "B")
-  |> should.equal("mailto:a%23b%40c.com?subject=S&body=B")
+  |> should.equal("mailto:a%23b@c.com?subject=S&body=B")
+}
+
+// Issue #21: the addr-spec `@` separator must remain literal per
+// RFC 6068 §2 — over-encoding it to `%40` broke canonical-form
+// matching in some QR-handler whitelists.
+pub fn email_to_keeps_at_literal_test() -> Nil {
+  content.email(
+    to: "user+tag@example.com",
+    subject: "Q & A",
+    body: "Hi#fragment",
+  )
+  |> should.equal(
+    "mailto:user+tag@example.com?subject=Q%20%26%20A&body=Hi%23fragment",
+  )
+}
+
+// Issue #21: `+` is in RFC 6068 §2 some-delims so it stays literal
+// in the addr-spec (sub-addressing tags like `user+tag` must survive
+// the round-trip).
+pub fn email_to_keeps_plus_literal_test() -> Nil {
+  content.email(to: "user+tag@example.com", subject: "", body: "")
+  |> should.equal("mailto:user+tag@example.com?subject=&body=")
+}
+
+// Issue #21: `,` separates multiple addr-specs in the `to` list per
+// RFC 6068 §2, so it must stay literal — encoding it would merge two
+// recipients into a single malformed local-part.
+pub fn email_to_comma_recipient_separator_test() -> Nil {
+  content.email(to: "a@x.com,b@y.com", subject: "S", body: "B")
+  |> should.equal("mailto:a@x.com,b@y.com?subject=S&body=B")
+}
+
+// Issue #21 regression guard: subject / body are hfvalues (not
+// addr-specs) so the wider RFC 3986 percent-encoding still applies
+// to `?` / `&` / `#` / space / `%` — only the `to` encoder was
+// narrowed.
+pub fn email_subject_body_still_encoded_test() -> Nil {
+  content.email(to: "u@e.com", subject: "a?b&c#d e", body: "x?y&z#w v")
+  |> should.equal(
+    "mailto:u@e.com?subject=a%3Fb%26c%23d%20e&body=x%3Fy%26z%23w%20v",
+  )
 }
 
 pub fn vcard_escapes_reserved_chars_test() -> Nil {


### PR DESCRIPTION
## Summary

The `to` field of `content.email` was being percent-encoded through `uri.percent_encode`, which over-encoded the addr-spec separator `@` (and other structural / some-delims characters) to `%40`. Per RFC 6068 §2, `@` is a literal separator between local-part and domain in `addr-spec`, so the canonical `mailto:` form must keep it literal. Closes #21.

## Changes

- New narrow addr-spec encoder for the `to` field that only escapes characters which actually break URI parsing in this position (space, `?`, `&`, `#`, `<`, `>`, control bytes, non-ASCII codepoints) while keeping `@`, `,`, and the RFC 6068 §2 some-delims set (`!`, `$`, `'`, `(`, `)`, `*`, `+`, `;`, `:`) literal.
- `subject` and `body` (`hfvalue` positions) keep the wider RFC 3986 percent-encoding the stdlib `uri.percent_encode` provides — the over-encoding fix is intentionally scoped to the `to` field only.
- Regression tests pin the new addr-spec behaviour (literal `@`, `+`, `,`) and that `subject` / `body` still encode `?`, `&`, `#` the same way as before.

## Design decisions

- A dedicated `to`-only encoder was preferred over post-processing the `uri.percent_encode` output (decoding `%40` etc. back to literal). Post-processing is order-sensitive and easy to break when stdlib changes the set of characters it encodes; a positive whitelist is auditable against RFC 6068 §2 directly.

Closes #21
