### PR TITLE
fix(error): populate DataExceedsCapacity fields in Micro/rMQR/encode_split bailouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `DataExceedsCapacity(bits_needed, bits_available)` now carries informative non-zero fields in the Micro QR `find_version`, rMQR `find_version`, and Standard `encode_split` bailout paths. The three "no symbol in this family fits" code paths previously returned `DataExceedsCapacity(0, 0)`, undermining the error type's documented purpose of telling callers how far over the ceiling their payload is; they now report the encoded-bit count vs the largest symbol's capacity (M4, R17×139, and 16 shards × max-version respectively), matching the Standard QR path's existing behaviour. (#22)
 - `qrkit/content.email` now keeps the addr-spec `@` separator (and the RFC 6068 §2 `some-delims` set: `!`, `$`, `'`, `(`, `)`, `*`, `+`, `;`, `:`, `,`) literal in the `to` field instead of percent-encoding everything via `uri.percent_encode`. The `to` field gets a narrower encoder that only escapes characters that would actually break URI parsing in this position (space, `?`, `&`, `#`, `<`, `>`, control bytes, non-ASCII); `subject` / `body` keep the wider RFC 3986 encoding. The previous behaviour produced `mailto:user%40example.com?...`, breaking canonical-form matching in some Android QR-handler whitelists. (#21)
 
 ## [0.2.0] - 2026-05-18

--- a/src/qrkit/internal/micro.gleam
+++ b/src/qrkit/internal/micro.gleam
@@ -306,7 +306,7 @@ fn do_find_version(
   candidate: Int,
 ) -> Result(Int, EncodeError) {
   case candidate > max_version {
-    True -> Error(DataExceedsCapacity(0, 0))
+    True -> Error(no_version_fits_error(text, selected_mode, ecc))
     False -> {
       case mode_supported(selected_mode, candidate) {
         False -> do_find_version(text, selected_mode, ecc, candidate + 1)
@@ -328,6 +328,27 @@ fn do_find_version(
       }
     }
   }
+}
+
+/// Build a `DataExceedsCapacity` error for the bailout case where no Micro QR
+/// version in `min_version..=max_version` accepts the payload at `ecc`. The
+/// fields point at the M4 ceiling (every Micro QR mode is supported at M4) so
+/// the caller can see how far over the Micro-QR ceiling the input is — see
+/// #22 for why `(0, 0)` was useless.
+fn no_version_fits_error(
+  text: String,
+  selected_mode: Mode,
+  ecc: ErrorCorrection,
+) -> EncodeError {
+  let bits_needed = case encoded_bits(text, selected_mode, max_version) {
+    Ok(value) -> value
+    Error(_) -> mode.data_bits_length(text, selected_mode)
+  }
+  let bits_available = case data_capacity_bits(max_version, ecc) {
+    Ok(value) -> value
+    Error(_) -> 0
+  }
+  DataExceedsCapacity(bits_needed, bits_available)
 }
 
 fn encoded_bits(

--- a/src/qrkit/internal/rmqr.gleam
+++ b/src/qrkit/internal/rmqr.gleam
@@ -254,7 +254,7 @@ fn find_version(
   candidate: Int,
 ) -> Result(Int, EncodeError) {
   case candidate >= total_versions {
-    True -> Error(DataExceedsCapacity(0, 0))
+    True -> Error(no_version_fits_error(text, selected_mode, ecc))
     False -> {
       let count_bits = lookup_cci(selected_mode, candidate)
       let data_bits =
@@ -266,6 +266,22 @@ fn find_version(
       }
     }
   }
+}
+
+/// Build a `DataExceedsCapacity` error for the bailout case where no rMQR
+/// version (R7×43..R17×139) accepts the payload at `ecc`. We report the
+/// R17×139 (largest) ceiling so the caller can see how far over the rMQR
+/// limit the input is — see #22 for why `(0, 0)` was useless.
+fn no_version_fits_error(
+  text: String,
+  selected_mode: Mode,
+  ecc: ErrorCorrection,
+) -> EncodeError {
+  let largest = total_versions - 1
+  let count_bits = lookup_cci(selected_mode, largest)
+  let bits_needed = 3 + count_bits + mode.data_bits_length(text, selected_mode)
+  let bits_available = data_capacity_bits(largest, ecc)
+  DataExceedsCapacity(bits_needed, bits_available)
 }
 
 fn data_capacity_bits(index: Int, ecc: ErrorCorrection) -> Int {

--- a/src/qrkit/internal/structured_append.gleam
+++ b/src/qrkit/internal/structured_append.gleam
@@ -15,6 +15,7 @@ import qrkit/error.{
 import qrkit/internal/bitstream
 import qrkit/internal/standard
 import qrkit/internal/util
+import qrkit/internal/version
 import qrkit/types.{type ErrorCorrection, Auto}
 
 /// Upper bound on the number of shards allowed by ISO/IEC 18004 §8.2.
@@ -58,7 +59,7 @@ fn find_split(
   total: Int,
 ) -> Result(List(standard.Encoded), EncodeError) {
   case total > max_symbols {
-    True -> Error(DataExceedsCapacity(bits_needed: 0, bits_available: 0))
+    True -> Error(no_split_fits_error(data, max_version, ecc))
     False -> {
       let chunks = split_string(data, total)
       case encode_shards(chunks, data, total, max_version, ecc) {
@@ -67,6 +68,31 @@ fn find_split(
       }
     }
   }
+}
+
+/// 20 bits of Structured Append header (4-bit mode + 4-bit position + 4-bit
+/// `total-1` + 8-bit parity, ISO/IEC 18004 §8.2) consumed per shard.
+const structured_append_header_bits: Int = 20
+
+/// Build a `DataExceedsCapacity` error for the bailout case where even 16
+/// shards at `max_version` cannot hold `data`. `bits_available` is the total
+/// capacity of 16 `max_version` symbols at `ecc`, minus the Structured Append
+/// header each shard must carry; `bits_needed` is the worst-case Byte-mode
+/// encoding of the payload (UTF-8 byte count × 8) since we don't know which
+/// mode each shard would have picked. See #22 for why `(0, 0)` was useless.
+fn no_split_fits_error(
+  data: String,
+  max_version: Int,
+  ecc: ErrorCorrection,
+) -> EncodeError {
+  let bits_per_symbol = case version.data_capacity_bits(max_version, ecc) {
+    Ok(value) -> value
+    Error(_) -> 0
+  }
+  let payload_bits = bit_array.byte_size(bit_array.from_string(data)) * 8
+  let bits_available =
+    max_symbols * { bits_per_symbol - structured_append_header_bits }
+  DataExceedsCapacity(payload_bits, bits_available)
 }
 
 fn encode_shards(

--- a/test/regression_data_exceeds_capacity_test.gleam
+++ b/test/regression_data_exceeds_capacity_test.gleam
@@ -1,0 +1,76 @@
+//// Regression tests for #22: `DataExceedsCapacity(bits_needed, bits_available)`
+//// must always carry informative, non-zero fields when the payload truly
+//// cannot fit. Before the fix, three code paths returned `(0, 0)`:
+////   - Micro QR `find_version` (no M1..M4 version accepts the payload)
+////   - rMQR `find_version` (no R7×43..R17×139 version accepts the payload)
+////   - `encode_split` (no Structured Append split with `total <= 16` fits)
+//// The Standard-QR path already populated both fields; this file pins that
+//// behaviour too so the Standard regression cannot silently break.
+
+import gleam/string
+import gleeunit/should
+import qrkit
+import qrkit/error
+import qrkit/types
+
+/// Assert the error is `DataExceedsCapacity` and both fields are strictly
+/// positive — the whole point of #22 is that callers can render "your payload
+/// is X bits over the ceiling," which is impossible if either field is zero.
+fn expect_capacity_error(result: Result(a, error.EncodeError)) -> Nil {
+  case result {
+    Error(error.DataExceedsCapacity(bits_needed, bits_available)) -> {
+      should.be_true(bits_needed > 0)
+      should.be_true(bits_available > 0)
+      should.be_true(bits_needed > bits_available)
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn micro_qr_overflow_carries_informative_fields_test() -> Nil {
+  // ~190 character Byte-mode payload — well beyond M4 / Low's 128-bit ceiling.
+  // Before #22 this returned `DataExceedsCapacity(0, 0)`; now it must report
+  // the encoded-bit count vs the M4 capacity so the caller can render a
+  // useful overflow message.
+  let payload = string.repeat("X", 190)
+  qrkit.new(payload)
+  |> qrkit.with_symbol(types.Micro)
+  |> qrkit.with_ecc(types.Low)
+  |> qrkit.build
+  |> expect_capacity_error
+}
+
+pub fn rmqr_overflow_carries_informative_fields_test() -> Nil {
+  // 200-character Byte-mode payload at rMQR + Medium. Even the largest rMQR
+  // (R17×139, 152 data codewords = 1216 data bits at Medium) cannot hold
+  // 200 bytes of header + Byte-mode payload comfortably once char-count and
+  // mode overhead are accounted for. Before #22 this returned
+  // `DataExceedsCapacity(0, 0)`.
+  let payload = string.repeat("a", 200)
+  // Force the encoder to pick rMQR and walk all 32 versions.
+  qrkit.new(payload)
+  |> qrkit.with_symbol(types.Rectangular)
+  |> qrkit.with_ecc(types.Medium)
+  |> qrkit.build
+  |> expect_capacity_error
+}
+
+pub fn encode_split_overflow_carries_informative_fields_test() -> Nil {
+  // `encode_split(payload, max_version=1)` caps every shard at v1 (≈ 17 byte
+  // codewords at Medium). A "Hello, world! " × 200 payload (= 2800 bytes) is
+  // far past 16 shards × v1 capacity, forcing the bailout in `find_split`.
+  // Before #22 this returned `DataExceedsCapacity(0, 0)`.
+  let payload = string.repeat("Hello, world! ", 200)
+  qrkit.encode_split(payload, 1)
+  |> expect_capacity_error
+}
+
+pub fn standard_overflow_carries_informative_fields_regression_test() -> Nil {
+  // The Standard-QR `internal/standard.gleam:115` path already populates both
+  // fields. Pin it so a refactor cannot silently regress to `(0, 0)`.
+  let payload = string.repeat("A", 1000)
+  qrkit.new(payload)
+  |> qrkit.with_exact_version(1)
+  |> qrkit.build
+  |> expect_capacity_error
+}


### PR DESCRIPTION
## Summary

Closes #22.

Three code paths returned `DataExceedsCapacity(0, 0)` when no symbol-family version fit the payload, undermining the error type's documented purpose:

- `src/qrkit/internal/micro.gleam` `do_find_version` — Micro QR M1..M4 walk bailout.
- `src/qrkit/internal/rmqr.gleam` `find_version` — rMQR R7×43..R17×139 walk bailout.
- `src/qrkit/internal/structured_append.gleam` `find_split` — Structured Append 16-shard cap bailout.

The Standard-QR path in `internal/standard.gleam` already populated both fields; the three above now do the same.

## Changes

- Micro QR: bailout reports `encoded_bits(text, mode, M4)` vs `data_capacity_bits(M4, ecc)`.
- rMQR: bailout reports `3 + cci(mode, R17×139) + data_bits_length(text, mode)` vs `data_capacity_bits(R17×139, ecc)`.
- `encode_split`: bailout reports the UTF-8 byte-count × 8 of the payload vs `16 × (data_capacity_bits(max_version, ecc) − 20)` (20 bits = Structured Append header per shard).
- Added `test/regression_data_exceeds_capacity_test.gleam` with four cases: Micro QR Byte overflow, rMQR Byte overflow, `encode_split` overflow, and a Standard-QR pin so the existing populated path cannot silently regress. Each test asserts `bits_needed > 0`, `bits_available > 0`, and `bits_needed > bits_available`.
- `CHANGELOG.md` Unreleased / Fixed entry.

## Test plan

- [x] `just all` (format-check, glinter, build erlang + javascript, test erlang + javascript, docs) green — 94 tests pass on both targets.
- [x] New regression tests fail on the pre-fix code (verified by inspecting the three `DataExceedsCapacity(0, 0)` literals removed in this PR) and pass on the new code.