### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.3.0] - 2026-05-21
+
 ### Fixed
 
 - README: the Sponsor QR image now uses an absolute `raw.githubusercontent.com` URL instead of the relative `docs/images/sponsor-qr.png` path so it renders both on GitHub and on the Hex package page (relative paths in the README cannot be resolved against the published package archive, which omits the `docs/images/` directory). (#23)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "qrkit"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pure Gleam QR code generator with terminal, SVG, and PNG rendering."
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "qrkit" }

--- a/src/qrkit.gleam
+++ b/src/qrkit.gleam
@@ -65,7 +65,7 @@ pub opaque type QrCode {
 
 /// The package version.
 pub fn package_version() -> String {
-  "0.2.0"
+  "0.3.0"
 }
 
 /// Create a new builder from input text.


### PR DESCRIPTION
### Fixed

- README: the Sponsor QR image now uses an absolute `raw.githubusercontent.com` URL instead of the relative `docs/images/sponsor-qr.png` path so it renders both on GitHub and on the Hex package page (relative paths in the README cannot be resolved against the published package archive, which omits the `docs/images/` directory). (#23)
- `DataExceedsCapacity(bits_needed, bits_available)` now carries informative non-zero fields in the Micro QR `find_version`, rMQR `find_version`, and Standard `encode_split` bailout paths. The three "no symbol in this family fits" code paths previously returned `DataExceedsCapacity(0, 0)`, undermining the error type's documented purpose of telling callers how far over the ceiling their payload is; they now report the encoded-bit count vs the largest symbol's capacity (M4, R17×139, and 16 shards × max-version respectively), matching the Standard QR path's existing behaviour. (#22)
- `qrkit/content.email` now keeps the addr-spec `@` separator (and the RFC 6068 §2 `some-delims` set: `!`, `$`, `'`, `(`, `)`, `*`, `+`, `;`, `:`, `,`) literal in the `to` field instead of percent-encoding everything via `uri.percent_encode`. The `to` field gets a narrower encoder that only escapes characters that would actually break URI parsing in this position (space, `?`, `&`, `#`, `<`, `>`, control bytes, non-ASCII); `subject` / `body` keep the wider RFC 3986 encoding. The previous behaviour produced `mailto:user%40example.com?...`, breaking canonical-form matching in some Android QR-handler whitelists. (#21)
