### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.4.0] - 2026-05-22
+
 ### Added
 
 - `qrkit/render/png` now exposes the same options-builder shape as `qrkit/render/svg` and `qrkit/render/ascii`: `default_options()`, `with_module_size`, `with_margin`, `with_dark_color`, `with_light_color`, `with_background`, and `to_bit_array_with(qr, options)`. The existing `to_bit_array(qr, scale:, margin:)` is preserved as a thin wrapper over the new path. Colour fields accept `#rgb`, `#rrggbb`, and `#rrggbbaa` strings (the alpha component is read but currently honoured only via the `with_background(False)` toggle, which marks the light palette entry transparent through a `tRNS` chunk); unparseable strings keep the previous value rather than failing the call, mirroring the SVG renderer's lenient parsing. Closes the parity gap left by #8. (#28)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "qrkit"
-version = "0.3.0"
+version = "0.4.0"
 description = "Pure Gleam QR code generator with terminal, SVG, and PNG rendering."
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "qrkit" }

--- a/src/qrkit.gleam
+++ b/src/qrkit.gleam
@@ -65,7 +65,7 @@ pub opaque type QrCode {
 
 /// The package version.
 pub fn package_version() -> String {
-  "0.3.0"
+  "0.4.0"
 }
 
 /// Create a new builder from input text.


### PR DESCRIPTION
### Added

- `qrkit/render/png` now exposes the same options-builder shape as `qrkit/render/svg` and `qrkit/render/ascii`: `default_options()`, `with_module_size`, `with_margin`, `with_dark_color`, `with_light_color`, `with_background`, and `to_bit_array_with(qr, options)`. The existing `to_bit_array(qr, scale:, margin:)` is preserved as a thin wrapper over the new path. Colour fields accept `#rgb`, `#rrggbb`, and `#rrggbbaa` strings (the alpha component is read but currently honoured only via the `with_background(False)` toggle, which marks the light palette entry transparent through a `tRNS` chunk); unparseable strings keep the previous value rather than failing the call, mirroring the SVG renderer's lenient parsing. Closes the parity gap left by #8. (#28)
